### PR TITLE
feat(ingestion): build download and extract pipeline stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,30 @@ jobs:
         working-directory: services/api
         run: pytest tests/ -v
 
+  validate-ingestion:
+    name: Validate Ingestion
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: services/ingestion/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r services/ingestion/requirements.txt
+
+      - name: Lint
+        working-directory: services/ingestion
+        run: ruff check .
+
+      - name: Run tests
+        working-directory: services/ingestion
+        run: pytest tests/ -v
+
   validate-web:
     name: Validate Web
     runs-on: ubuntu-latest

--- a/services/ingestion/corpus_manifest.yaml
+++ b/services/ingestion/corpus_manifest.yaml
@@ -2,11 +2,80 @@
 # One entry per document. Add entries here before running the download pipeline.
 #
 # Fields:
-#   union:     Union name (slug, lowercase-kebab)
-#   type:      primary_ca | nuclear_pa | moa_supplement | wage_schedule
-#   title:     Human-readable document title
-#   url:       Source URL on epsca.org/resources
-#   filename:  Target filename in corpus/ directory
-#   effective: Effective date (YYYY-MM-DD)
+#   union_name:      Union display name (matches documents.union_name in PostgreSQL)
+#   document_type:   primary_ca | nuclear_pa | moa_supplement | wage_schedule
+#   agreement_scope: generation | transmission | null (only for IBEW and Labourers)
+#   title:           Full document title as listed on epsca.org/resources
+#   source_url:      Direct download URL from epsca.org. Set to PLACEHOLDER if
+#                    the URL must be obtained manually from the EPSCA website.
+#   source_filename: Target filename in corpus/{union-slug}/{document_type}/
+#   effective_date:  Agreement or wage schedule effective date (YYYY-MM-DD)
+#   expiry_date:     Agreement expiry date (YYYY-MM-DD); null for open-ended documents
+#
+# Phase 1 POC — 6 documents: IBEW Generation, Sheet Metal, United Association
+# (3 primary CAs + 3 Nuclear Project Agreements)
+#
+# NOTE: source_url values below are PLACEHOLDER — visit https://www.epsca.org/resources
+# to obtain the current direct download links before running `python download.py`.
 
-documents: []
+documents:
+
+  # ─── IBEW ──────────────────────────────────────────────────────────────────
+
+  - union_name: "IBEW"
+    document_type: "primary_ca"
+    agreement_scope: "generation"
+    title: "IBEW Generation 2025-2030 Collective Agreement"
+    source_url: "PLACEHOLDER - see https://www.epsca.org/resources"
+    source_filename: "IBEW Generation- 2025-2030 Collective Agreement.pdf"
+    effective_date: "2025-05-01"
+    expiry_date: "2030-04-30"
+
+  - union_name: "IBEW"
+    document_type: "nuclear_pa"
+    agreement_scope: "generation"
+    title: "IBEW Nuclear Project Agreement"
+    source_url: "PLACEHOLDER - see https://www.epsca.org/resources"
+    source_filename: "IBEW Nuclear Project Agreement.pdf"
+    effective_date: "2025-05-01"
+    expiry_date: "2030-04-30"
+
+  # ─── Sheet Metal ───────────────────────────────────────────────────────────
+
+  - union_name: "Sheet Metal"
+    document_type: "primary_ca"
+    agreement_scope: null
+    title: "Sheet Metal Workers 2025-2030 Collective Agreement"
+    source_url: "PLACEHOLDER - see https://www.epsca.org/resources"
+    source_filename: "Sheet Metal - 2025-2030 Collective Agreement.pdf"
+    effective_date: "2025-05-01"
+    expiry_date: "2030-04-30"
+
+  - union_name: "Sheet Metal"
+    document_type: "nuclear_pa"
+    agreement_scope: null
+    title: "Sheet Metal Nuclear Project Agreement"
+    source_url: "PLACEHOLDER - see https://www.epsca.org/resources"
+    source_filename: "Sheet Metal Nuclear Project Agreement.pdf"
+    effective_date: "2025-05-01"
+    expiry_date: "2030-04-30"
+
+  # ─── United Association ────────────────────────────────────────────────────
+
+  - union_name: "United Association"
+    document_type: "primary_ca"
+    agreement_scope: null
+    title: "United Association 2025-2030 Collective Agreement"
+    source_url: "PLACEHOLDER - see https://www.epsca.org/resources"
+    source_filename: "United Association - 2025-2030 Collective Agreement.pdf"
+    effective_date: "2025-05-01"
+    expiry_date: "2030-04-30"
+
+  - union_name: "United Association"
+    document_type: "nuclear_pa"
+    agreement_scope: null
+    title: "United Association Nuclear Project Agreement"
+    source_url: "PLACEHOLDER - see https://www.epsca.org/resources"
+    source_filename: "United Association Nuclear Project Agreement.pdf"
+    effective_date: "2025-05-01"
+    expiry_date: "2030-04-30"

--- a/services/ingestion/download.py
+++ b/services/ingestion/download.py
@@ -1,0 +1,156 @@
+"""
+Stage 1: Download — fetch PDFs from EPSCA and store locally.
+
+Downloads all documents listed in corpus_manifest.yaml into the corpus/
+directory, organised as corpus/{union-slug}/{document_type}/{filename}.
+
+Idempotent: files that already exist on disk are skipped (not re-downloaded).
+Entries with missing or placeholder source_url values are skipped with status
+NO_URL and must be placed manually before running the pipeline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+import httpx
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_HERE = Path(__file__).parent
+CORPUS_MANIFEST = _HERE / "corpus_manifest.yaml"
+CORPUS_DIR = _HERE / "corpus"
+
+
+class DownloadStatus(StrEnum):
+    DOWNLOADED = "downloaded"
+    SKIPPED = "skipped"    # file already present on disk — hash recorded
+    NO_URL = "no_url"      # source_url absent or placeholder — manual placement needed
+    FAILED = "failed"      # network or HTTP error
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    source_filename: str
+    status: DownloadStatus
+    file_hash: str | None = None
+    error: str | None = None
+
+
+def union_slug(union_name: str) -> str:
+    """Convert a union display name to a lowercase-kebab directory slug."""
+    return union_name.lower().replace(" ", "-")
+
+
+def resolve_corpus_path(entry: dict[str, str], corpus_dir: Path) -> Path:
+    """Return the target filesystem path for a corpus manifest entry."""
+    slug = union_slug(entry["union_name"])
+    return corpus_dir / slug / entry["document_type"] / entry["source_filename"]
+
+
+def compute_sha256(path: Path) -> str:
+    """Return the SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+async def download_document(
+    entry: dict[str, str],
+    corpus_dir: Path,
+    client: httpx.AsyncClient,
+) -> DownloadResult:
+    """
+    Download a single document from its source_url, or skip if already present.
+
+    Args:
+        entry:      A corpus manifest document entry (dict).
+        corpus_dir: Root directory for downloaded corpus files.
+        client:     An active httpx.AsyncClient for HTTP requests.
+
+    Returns:
+        DownloadResult describing the outcome.
+    """
+    # Use .get() so a malformed entry doesn't abort the whole pipeline
+    source_filename = entry.get("source_filename", "<unknown>")
+    source_url = entry.get("source_url", "")
+
+    if not source_url or source_url.startswith("PLACEHOLDER"):
+        logger.info("No URL for %s — skipping (manual placement required)", source_filename)
+        return DownloadResult(source_filename=source_filename, status=DownloadStatus.NO_URL)
+
+    try:
+        target = resolve_corpus_path(entry, corpus_dir)
+
+        if target.exists():
+            file_hash = compute_sha256(target)
+            logger.info("Already present: %s (sha256=%.8s…)", source_filename, file_hash)
+            return DownloadResult(
+                source_filename=source_filename,
+                status=DownloadStatus.SKIPPED,
+                file_hash=file_hash,
+            )
+
+        logger.info("Downloading %s", source_filename)
+        response = await client.get(source_url, follow_redirects=True)
+        response.raise_for_status()
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        # Atomic write: write to a temp file then rename so a crash mid-write
+        # does not leave a partial file that would be treated as complete on retry.
+        tmp = target.with_suffix(".tmp")
+        try:
+            tmp.write_bytes(response.content)
+            tmp.rename(target)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+        file_hash = compute_sha256(target)
+        logger.info("Downloaded  %s (sha256=%.8s…)", source_filename, file_hash)
+        return DownloadResult(
+            source_filename=source_filename,
+            status=DownloadStatus.DOWNLOADED,
+            file_hash=file_hash,
+        )
+    except (httpx.HTTPError, KeyError) as exc:
+        logger.error("Failed to download %s: %s", source_filename, exc)
+        return DownloadResult(
+            source_filename=source_filename,
+            status=DownloadStatus.FAILED,
+            error=str(exc),
+        )
+
+
+async def run_download(
+    manifest_path: Path = CORPUS_MANIFEST,
+    corpus_dir: Path = CORPUS_DIR,
+) -> list[DownloadResult]:
+    """
+    Run the download stage for all documents in the corpus manifest.
+
+    Args:
+        manifest_path: Path to corpus_manifest.yaml.
+        corpus_dir:    Root directory for downloaded corpus files.
+
+    Returns:
+        A list of DownloadResult, one per manifest entry.
+    """
+    with manifest_path.open() as f:
+        manifest = yaml.safe_load(f) or {}
+
+    documents: list[dict[str, str]] = manifest.get("documents", [])
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        results = []
+        for entry in documents:
+            result = await download_document(entry, corpus_dir, client)
+            results.append(result)
+
+    return results

--- a/services/ingestion/extract.py
+++ b/services/ingestion/extract.py
@@ -1,0 +1,112 @@
+"""
+Stage 2: Extract — extract raw text and tables from PDFs.
+
+For each PDF in the corpus, extracts:
+- Full text blocks per page, with 1-indexed page numbers preserved
+- Structured table blocks per page, flagged with is_table=True
+
+Output feeds into Stage 3 (classify.py) which assigns document metadata,
+and Stage 4 (chunk.py) which applies structure-aware chunking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pdfplumber
+
+# Type alias for an immutable table (tuple-of-tuples preserves frozen semantics)
+TableRows = tuple[tuple[str | None, ...], ...]
+
+
+@dataclass(frozen=True)
+class TextBlock:
+    """A prose text block extracted from a single PDF page."""
+
+    text: str
+    page_number: int
+    is_table: bool = False
+
+
+@dataclass(frozen=True)
+class TableBlock:
+    """A structured table extracted from a single PDF page.
+
+    `rows` is stored as a tuple-of-tuples so that frozen=True actually prevents
+    mutation.  Downstream consumers iterate rows — they do not need mutability.
+    """
+
+    rows: TableRows
+    page_number: int
+    is_table: bool = True
+
+
+@dataclass
+class ExtractedDocument:
+    """All content extracted from a single PDF file."""
+
+    source_path: Path
+    blocks: list[TextBlock | TableBlock] = field(default_factory=list)
+    page_count: int = 0
+
+
+def _to_table_rows(raw: list[list[str | None]]) -> TableRows:
+    """Convert pdfplumber's list-of-lists into an immutable tuple-of-tuples."""
+    return tuple(tuple(row) for row in raw)
+
+
+def extract_pdf(pdf_path: Path) -> ExtractedDocument:
+    """
+    Extract text and tables from a PDF file.
+
+    Each page is processed independently. Text and table blocks carry the
+    1-indexed page number as reported by pdfplumber. Empty or whitespace-only
+    pages produce no text block.
+
+    Args:
+        pdf_path: Absolute path to the PDF file.
+
+    Returns:
+        ExtractedDocument containing all text and table blocks with page numbers.
+
+    Raises:
+        FileNotFoundError: If pdf_path does not exist.
+        ValueError:        If pdfplumber cannot parse the file (corrupt, encrypted,
+                           or not a valid PDF).
+    """
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    doc = ExtractedDocument(source_path=pdf_path)
+
+    try:
+        with pdfplumber.open(pdf_path) as pdf:
+            doc.page_count = len(pdf.pages)
+            for page in pdf.pages:
+                page_num: int = page.page_number  # pdfplumber is 1-indexed
+
+                # Extract tables — each table is a list of rows, each row a list of cells
+                raw_tables: list[list[list[str | None]]] = page.extract_tables()
+                for table_data in raw_tables:
+                    if table_data:
+                        doc.blocks.append(
+                            TableBlock(
+                                rows=_to_table_rows(table_data),
+                                page_number=page_num,
+                            )
+                        )
+
+                # Extract full page text (may overlap with table regions — deduplication
+                # is handled downstream in the chunk stage)
+                raw_text: str | None = page.extract_text(x_tolerance=3, y_tolerance=3)
+                text = (raw_text or "").strip()
+                if text:
+                    doc.blocks.append(TextBlock(text=text, page_number=page_num))
+    except Exception as exc:
+        # pdfminer (pdfplumber's parser) raises several exception types for corrupt,
+        # truncated, or encrypted PDFs.  Convert to ValueError so callers get a
+        # stable contract and can decide whether to skip or abort.
+        raise ValueError(f"Failed to parse PDF {pdf_path}: {exc}") from exc
+
+    return doc

--- a/services/ingestion/pyproject.toml
+++ b/services/ingestion/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.mypy]
+strict = true
+ignore_missing_imports = true
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "S", "BLE"]
+ignore = ["S101"]  # allow assert in tests
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/services/ingestion/requirements.txt
+++ b/services/ingestion/requirements.txt
@@ -4,3 +4,9 @@ pyyaml>=6.0.0
 qdrant-client>=1.9.0
 asyncpg>=0.29.0
 tqdm>=4.66.0
+
+# Dev / test
+ruff>=0.4.0
+mypy>=1.10.0
+pytest>=8.2.0
+pytest-asyncio>=0.23.0

--- a/services/ingestion/run_pipeline.py
+++ b/services/ingestion/run_pipeline.py
@@ -1,6 +1,56 @@
 """
 Ingestion pipeline orchestrator.
 
-Run stages in order:
-    python run_pipeline.py [--stage download|extract|classify|chunk|embed|store|all]
+Runs pipeline stages in order. Use --stage to run a single stage or
+omit it to run all stages sequentially.
+
+Usage:
+    python run_pipeline.py --stage download
+    python run_pipeline.py --stage extract
+    python run_pipeline.py           # runs all stages
 """
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("run_pipeline")
+
+STAGES = ["download", "extract", "classify", "chunk", "embed", "store"]
+
+
+async def run_stage(stage: str) -> None:
+    if stage == "download":
+        from download import run_download
+
+        results = await run_download()
+        for r in results:
+            detail = r.file_hash or r.error or ""
+            logger.info("[%s] %s — %s", r.status.value.upper(), r.source_filename, detail)
+    elif stage == "extract":
+        logger.info("Extract stage not yet wired to orchestrator — run extract.py directly")
+    else:
+        logger.warning("Stage '%s' not yet implemented", stage)
+
+
+async def main(stages: list[str]) -> None:
+    for stage in stages:
+        logger.info("=== Stage: %s ===", stage)
+        await run_stage(stage)
+    logger.info("Pipeline complete.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="EPSCAxplor ingestion pipeline")
+    parser.add_argument(
+        "--stage",
+        choices=STAGES,
+        default=None,
+        help="Run a single stage (default: run all stages)",
+    )
+    args = parser.parse_args()
+    selected = [args.stage] if args.stage else STAGES
+    asyncio.run(main(selected))

--- a/services/ingestion/tests/conftest.py
+++ b/services/ingestion/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Shared pytest fixtures for ingestion pipeline tests."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def make_mock_page(
+    page_number: int,
+    text: str | None,
+    tables: list[list[list[str | None]]] | None = None,
+) -> MagicMock:
+    """Build a mock pdfplumber Page object."""
+    page = MagicMock()
+    page.page_number = page_number
+    page.extract_text.return_value = text
+    page.extract_tables.return_value = tables or []
+    return page
+
+
+def make_mock_pdf(pages: list[MagicMock]) -> MagicMock:
+    """Build a mock pdfplumber PDF context manager."""
+    mock_pdf = MagicMock()
+    mock_pdf.__enter__.return_value = mock_pdf
+    mock_pdf.__exit__.return_value = False
+    mock_pdf.pages = pages
+    return mock_pdf
+
+
+@pytest.fixture()
+def tmp_pdf(tmp_path: Path) -> Path:
+    """A temporary file that exists but is not a real PDF (used for path-exist tests)."""
+    p = tmp_path / "test.pdf"
+    p.write_bytes(b"%PDF-1.4 fake")
+    return p

--- a/services/ingestion/tests/test_download.py
+++ b/services/ingestion/tests/test_download.py
@@ -1,0 +1,254 @@
+"""Tests for download.py — Stage 1 of the ingestion pipeline."""
+
+import hashlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+from download import (
+    DownloadStatus,
+    compute_sha256,
+    download_document,
+    resolve_corpus_path,
+    union_slug,
+)
+
+
+class TestUnionSlug:
+    def test_lowercase_conversion(self) -> None:
+        assert union_slug("IBEW") == "ibew"
+
+    def test_spaces_become_hyphens(self) -> None:
+        assert union_slug("Sheet Metal") == "sheet-metal"
+
+    def test_already_lowercase_unchanged(self) -> None:
+        assert union_slug("boilermakers") == "boilermakers"
+
+    def test_mixed_case_with_spaces(self) -> None:
+        assert union_slug("United Association") == "united-association"
+
+
+class TestResolveCorpusPath:
+    def test_path_structure(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW Generation- 2025-2030 Collective Agreement.pdf",
+        }
+        result = resolve_corpus_path(entry, tmp_path)
+        filename = "IBEW Generation- 2025-2030 Collective Agreement.pdf"
+        assert result == tmp_path / "ibew" / "primary_ca" / filename
+
+    def test_nuclear_pa_path(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "Sheet Metal",
+            "document_type": "nuclear_pa",
+            "source_filename": "Sheet Metal Nuclear Project Agreement.pdf",
+        }
+        result = resolve_corpus_path(entry, tmp_path)
+        filename = "Sheet Metal Nuclear Project Agreement.pdf"
+        assert result == tmp_path / "sheet-metal" / "nuclear_pa" / filename
+
+
+class TestComputeSha256:
+    def test_known_hash(self, tmp_path: Path) -> None:
+        content = b"hello world"
+        f = tmp_path / "test.bin"
+        f.write_bytes(content)
+        expected = hashlib.sha256(content).hexdigest()
+        assert compute_sha256(f) == expected
+
+    def test_different_content_different_hash(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "a.bin"
+        f2 = tmp_path / "b.bin"
+        f1.write_bytes(b"content a")
+        f2.write_bytes(b"content b")
+        assert compute_sha256(f1) != compute_sha256(f2)
+
+    def test_same_content_same_hash(self, tmp_path: Path) -> None:
+        content = b"deterministic"
+        f1 = tmp_path / "a.bin"
+        f2 = tmp_path / "b.bin"
+        f1.write_bytes(content)
+        f2.write_bytes(content)
+        assert compute_sha256(f1) == compute_sha256(f2)
+
+
+def _make_async_client(status_code: int = 200, content: bytes = b"%PDF fake") -> AsyncMock:
+    """Build an AsyncMock httpx.AsyncClient that returns a successful response."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.content = content
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    return mock_client
+
+
+def _make_error_client(error: Exception) -> AsyncMock:
+    """Build an AsyncMock httpx.AsyncClient that raises an error."""
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = error
+    return mock_client
+
+
+class TestDownloadDocument:
+    async def test_downloads_file_to_correct_path(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW Gen CA.pdf",
+            "source_url": "https://example.com/ibew.pdf",
+        }
+        client = _make_async_client()
+        result = await download_document(entry, tmp_path, client)
+
+        assert result.status == DownloadStatus.DOWNLOADED
+        target = tmp_path / "ibew" / "primary_ca" / "IBEW Gen CA.pdf"
+        assert target.exists()
+
+    async def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "United Association",
+            "document_type": "nuclear_pa",
+            "source_filename": "UA NPA.pdf",
+            "source_url": "https://example.com/ua-npa.pdf",
+        }
+        client = _make_async_client()
+        await download_document(entry, tmp_path, client)
+
+        target = tmp_path / "united-association" / "nuclear_pa" / "UA NPA.pdf"
+        assert target.exists()
+
+    async def test_returns_file_hash_on_success(self, tmp_path: Path) -> None:
+        content = b"%PDF actual content"
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW.pdf",
+            "source_url": "https://example.com/ibew.pdf",
+        }
+        client = _make_async_client(content=content)
+        result = await download_document(entry, tmp_path, client)
+
+        assert result.status == DownloadStatus.DOWNLOADED
+        expected_hash = hashlib.sha256(content).hexdigest()
+        assert result.file_hash == expected_hash
+
+    async def test_skips_already_existing_file(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW.pdf",
+            "source_url": "https://example.com/ibew.pdf",
+        }
+        target = tmp_path / "ibew" / "primary_ca" / "IBEW.pdf"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"%PDF existing")
+
+        client = _make_async_client()
+        result = await download_document(entry, tmp_path, client)
+
+        assert result.status == DownloadStatus.SKIPPED
+        client.get.assert_not_called()
+
+    async def test_skip_returns_existing_file_hash(self, tmp_path: Path) -> None:
+        content = b"%PDF existing content"
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW.pdf",
+            "source_url": "https://example.com/ibew.pdf",
+        }
+        target = tmp_path / "ibew" / "primary_ca" / "IBEW.pdf"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(content)
+
+        client = _make_async_client()
+        result = await download_document(entry, tmp_path, client)
+
+        assert result.file_hash == hashlib.sha256(content).hexdigest()
+
+    async def test_returns_no_url_for_missing_source_url(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW.pdf",
+        }
+        client = _make_async_client()
+        result = await download_document(entry, tmp_path, client)
+
+        assert result.status == DownloadStatus.NO_URL
+        client.get.assert_not_called()
+
+    async def test_returns_no_url_for_placeholder_url(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW.pdf",
+            "source_url": "PLACEHOLDER - see https://www.epsca.org/resources",
+        }
+        client = _make_async_client()
+        result = await download_document(entry, tmp_path, client)
+
+        assert result.status == DownloadStatus.NO_URL
+
+    async def test_returns_failed_on_http_error(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW.pdf",
+            "source_url": "https://example.com/ibew.pdf",
+        }
+        client = _make_error_client(httpx.ConnectError("Connection refused"))
+        result = await download_document(entry, tmp_path, client)
+
+        assert result.status == DownloadStatus.FAILED
+        assert result.file_hash is None
+        assert result.error is not None
+
+    async def test_returns_failed_on_http_status_error(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW.pdf",
+            "source_url": "https://example.com/ibew.pdf",
+        }
+        mock_response = MagicMock()
+        mock_response.content = b""
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404 Not Found",
+            request=MagicMock(),
+            response=MagicMock(),
+        )
+        client = AsyncMock()
+        client.get.return_value = mock_response
+
+        result = await download_document(entry, tmp_path, client)
+
+        assert result.status == DownloadStatus.FAILED
+
+    async def test_source_filename_is_always_in_result(self, tmp_path: Path) -> None:
+        entry = {
+            "union_name": "IBEW",
+            "document_type": "primary_ca",
+            "source_filename": "IBEW Gen CA.pdf",
+        }
+        client = _make_async_client()
+        result = await download_document(entry, tmp_path, client)
+        assert result.source_filename == "IBEW Gen CA.pdf"
+
+    async def test_malformed_entry_missing_required_key_returns_failed(
+        self, tmp_path: Path
+    ) -> None:
+        # Missing union_name and document_type — resolve_corpus_path would KeyError
+        entry = {
+            "source_filename": "Mystery.pdf",
+            "source_url": "https://example.com/mystery.pdf",
+        }
+        client = _make_async_client()
+        result = await download_document(entry, tmp_path, client)
+        assert result.status == DownloadStatus.FAILED
+        assert result.error is not None

--- a/services/ingestion/tests/test_extract.py
+++ b/services/ingestion/tests/test_extract.py
@@ -1,0 +1,195 @@
+"""Tests for extract.py — Stage 2 of the ingestion pipeline."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from extract import ExtractedDocument, TableBlock, TableRows, TextBlock, extract_pdf
+from tests.conftest import make_mock_page, make_mock_pdf
+
+
+class TestExtractPdf:
+    def test_raises_file_not_found_for_missing_pdf(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.pdf"
+        with pytest.raises(FileNotFoundError, match="nonexistent.pdf"):
+            extract_pdf(missing)
+
+    def test_returns_extracted_document(self, tmp_pdf: Path) -> None:
+        pages = [make_mock_page(1, "Some text")]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+        assert isinstance(result, ExtractedDocument)
+
+    def test_page_count_is_populated(self, tmp_pdf: Path) -> None:
+        pages = [make_mock_page(1, "Page 1"), make_mock_page(2, "Page 2")]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+        assert result.page_count == 2
+
+    def test_source_path_is_set(self, tmp_pdf: Path) -> None:
+        pages = [make_mock_page(1, "Text")]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+        assert result.source_path == tmp_pdf
+
+
+class TestPageNumberPreservation:
+    def test_text_block_carries_page_number(self, tmp_pdf: Path) -> None:
+        pages = [
+            make_mock_page(1, "First page content"),
+            make_mock_page(2, "Second page content"),
+        ]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        text_blocks = [b for b in result.blocks if isinstance(b, TextBlock)]
+        page_numbers = {b.page_number for b in text_blocks}
+        assert 1 in page_numbers
+        assert 2 in page_numbers
+
+    def test_page_numbers_match_pdfplumber_page_number(self, tmp_pdf: Path) -> None:
+        # pdfplumber uses 1-indexed page numbers; we must pass them through unchanged
+        pages = [make_mock_page(page_number=3, text="Deep into a document")]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        text_blocks = [b for b in result.blocks if isinstance(b, TextBlock)]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].page_number == 3
+
+    def test_table_block_carries_page_number(self, tmp_pdf: Path) -> None:
+        table_data = [["Classification", "Rate"], ["Journeyperson", "$45.00"]]
+        pages = [make_mock_page(5, "Wage Schedule", tables=[table_data])]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        table_blocks = [b for b in result.blocks if isinstance(b, TableBlock)]
+        assert len(table_blocks) == 1
+        assert table_blocks[0].page_number == 5
+
+
+class TestTableFlagging:
+    def test_table_block_is_flagged_as_table(self, tmp_pdf: Path) -> None:
+        table_data = [["Col A", "Col B"], ["1", "2"]]
+        pages = [make_mock_page(1, "Some text", tables=[table_data])]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        table_blocks = [b for b in result.blocks if isinstance(b, TableBlock)]
+        assert len(table_blocks) == 1
+        assert table_blocks[0].is_table is True
+
+    def test_text_block_is_not_flagged_as_table(self, tmp_pdf: Path) -> None:
+        pages = [make_mock_page(1, "ARTICLE 12 — Overtime")]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        text_blocks = [b for b in result.blocks if isinstance(b, TextBlock)]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].is_table is False
+
+    def test_page_with_table_produces_both_text_and_table_blocks(self, tmp_pdf: Path) -> None:
+        table_data = [["Article", "Rate"], ["12.01", "$45.00"]]
+        pages = [make_mock_page(1, "ARTICLE 12 Overtime\n12.01 Hourly Rate", tables=[table_data])]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        text_blocks = [b for b in result.blocks if isinstance(b, TextBlock)]
+        table_blocks = [b for b in result.blocks if isinstance(b, TableBlock)]
+        assert len(text_blocks) == 1
+        assert len(table_blocks) == 1
+
+    def test_table_rows_are_preserved_as_tuples(self, tmp_pdf: Path) -> None:
+        table_data = [
+            ["Classification", "Hourly Rate", "Vacation Pay"],
+            ["Journeyperson", "$45.00", "10%"],
+            ["Apprentice", "$36.00", "10%"],
+        ]
+        pages = [make_mock_page(1, "Wage Schedule", tables=[table_data])]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        table_blocks = [b for b in result.blocks if isinstance(b, TableBlock)]
+        # rows are stored as tuple-of-tuples for true immutability
+        expected: TableRows = tuple(tuple(row) for row in table_data)
+        assert table_blocks[0].rows == expected
+
+    def test_table_rows_are_immutable(self, tmp_pdf: Path) -> None:
+        table_data = [["A", "B"], ["1", "2"]]
+        pages = [make_mock_page(1, "Text", tables=[table_data])]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        block = next(b for b in result.blocks if isinstance(b, TableBlock))
+        # frozen=True + tuple rows: both attribute reassignment and in-place
+        # mutation should be impossible
+        with pytest.raises((TypeError, AttributeError)):
+            block.rows = ()  # type: ignore[misc]
+
+    def test_multiple_tables_on_one_page(self, tmp_pdf: Path) -> None:
+        table1 = [["A", "B"], ["1", "2"]]
+        table2 = [["X", "Y"], ["3", "4"]]
+        pages = [make_mock_page(1, "Page with two tables", tables=[table1, table2])]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        table_blocks = [b for b in result.blocks if isinstance(b, TableBlock)]
+        assert len(table_blocks) == 2
+
+
+class TestErrorHandling:
+    def test_raises_value_error_for_corrupt_pdf(self, tmp_pdf: Path) -> None:
+        with patch("extract.pdfplumber.open", side_effect=Exception("No /Root object!")):
+            with pytest.raises(ValueError, match="Failed to parse PDF"):
+                extract_pdf(tmp_pdf)
+
+    def test_value_error_chains_original_exception(self, tmp_pdf: Path) -> None:
+        original = Exception("PDFSyntaxError: unexpected token")
+        with patch("extract.pdfplumber.open", side_effect=original):
+            with pytest.raises(ValueError) as exc_info:
+                extract_pdf(tmp_pdf)
+        assert exc_info.value.__cause__ is original
+
+
+class TestEdgeCases:
+    def test_empty_page_produces_no_text_block(self, tmp_pdf: Path) -> None:
+        pages = [make_mock_page(1, None), make_mock_page(2, "")]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        text_blocks = [b for b in result.blocks if isinstance(b, TextBlock)]
+        assert len(text_blocks) == 0
+
+    def test_whitespace_only_page_produces_no_text_block(self, tmp_pdf: Path) -> None:
+        pages = [make_mock_page(1, "   \n\t  ")]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        text_blocks = [b for b in result.blocks if isinstance(b, TextBlock)]
+        assert len(text_blocks) == 0
+
+    def test_multi_page_document_preserves_all_pages(self, tmp_pdf: Path) -> None:
+        pages = [make_mock_page(i, f"Content of page {i}") for i in range(1, 6)]
+        mock_pdf = make_mock_pdf(pages)
+        with patch("extract.pdfplumber.open", return_value=mock_pdf):
+            result = extract_pdf(tmp_pdf)
+
+        text_blocks = [b for b in result.blocks if isinstance(b, TextBlock)]
+        assert len(text_blocks) == 5
+        extracted_page_nums = sorted(b.page_number for b in text_blocks)
+        assert extracted_page_nums == [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary

- **`download.py`** — downloads PDFs from `corpus_manifest.yaml` into `corpus/{union-slug}/{type}/`. Idempotent (skips existing files), atomic write via `.tmp` → rename, `PLACEHOLDER` URLs return `NO_URL` status, malformed entries return `FAILED` without aborting remaining downloads.
- **`extract.py`** — extracts text blocks and table blocks from PDFs using pdfplumber. Page numbers preserved 1-indexed from pdfplumber. `TableBlock.rows` is `tuple[tuple[...]]` (frozen=True actually enforced). pdfminer exceptions wrapped as `ValueError`.
- **`corpus_manifest.yaml`** — scaffolded with 6 POC entries (IBEW Generation, Sheet Metal, United Association — 3 primary CAs + 3 NPAs). `source_url` values are `PLACEHOLDER`; fill from epsca.org/resources before running.
- **`ci.yml`** — adds `validate-ingestion` job (ruff lint + pytest).

## Test plan

- [ ] 38 tests pass locally: `pytest tests/ -v` from `services/ingestion/`
- [ ] `ruff check .` passes with no errors
- [ ] CI validate-ingestion job passes on this branch
- [ ] Verify `source_url` placeholders replaced before running issue #14 (ops: run ingestion)

Closes #11