### PR TITLE
feat(ingestion): build classify and chunk pipeline stages

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,20 @@
       "Bash(echo \"--- mypy exit: $?\")",
       "Bash(python3 -m bandit -r src/)",
       "Bash(echo \"--- bandit exit: $?\")",
-      "Bash(python3 -m pytest tests/ -v)"
+      "Bash(python3 -m pytest tests/ -v)",
+      "Bash(git checkout *)",
+      "Bash(python -m pytest tests/ -v)",
+      "Bash(python3 -m ruff check .)",
+      "Bash(python -m ruff check download.py extract.py)",
+      "Bash(python3 -m ruff check download.py extract.py)",
+      "Bash(python3 -m mypy download.py extract.py --strict)",
+      "Bash(python3 -m bandit -r /media/boilerrat/Bobby/EPSCAxplor/services/ingestion/download.py /media/boilerrat/Bobby/EPSCAxplor/services/ingestion/extract.py)",
+      "Bash(gh pr create --repo BoilerHAUS/EPSCAxplor --title 'feat\\(ingestion\\): build download and extract pipeline stages' --body ' *)",
+      "Read(//home/boilerrat/Downloads/**)",
+      "Bash(git rm *)",
+      "Bash(python -m pytest tests/test_classify.py tests/test_chunk.py -v)",
+      "Bash(python3 -m pytest tests/test_classify.py tests/test_chunk.py -v)",
+      "Bash(python3 -m pytest -v)"
     ],
     "additionalDirectories": [
       "/home/boilerrat/.claude/sessions"

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -37,7 +37,7 @@ Goal: End-to-end pipeline validated against 3 unions (IBEW Generation, Sheet Met
 | # | type | status | title |
 |---|------|--------|-------|
 | [#11](https://github.com/BoilerHAUS/EPSCAxplor/issues/11) | pr | [ ] | feat(ingestion): build download and extract pipeline stages |
-| [#12](https://github.com/BoilerHAUS/EPSCAxplor/issues/12) | pr | [ ] | feat(ingestion): build classify and chunk pipeline stages |
+| [#12](https://github.com/BoilerHAUS/EPSCAxplor/issues/12) | pr | [x] | feat(ingestion): build classify and chunk pipeline stages |
 | [#13](https://github.com/BoilerHAUS/EPSCAxplor/issues/13) | pr | [ ] | feat(ingestion): build embed, store, and pipeline orchestrator |
 | [#14](https://github.com/BoilerHAUS/EPSCAxplor/issues/14) | no-pr | [ ] | ops: run Phase 1 POC ingestion (IBEW Generation, Sheet Metal, UA) |
 | [#15](https://github.com/BoilerHAUS/EPSCAxplor/issues/15) | pr | [ ] | feat(rag): implement query pre-processing (nuclear detection, union/scope detection) |

--- a/services/ingestion/chunk.py
+++ b/services/ingestion/chunk.py
@@ -1,0 +1,365 @@
+"""
+Stage 4: Chunk — structure-aware chunking of classified documents.
+
+Splits each ClassifiedDocument into Chunk objects following the rules defined
+in planning.md §6:
+
+1. Split at article boundaries (ARTICLE N — TITLE headings) first.
+2. If an article exceeds the token limit, split at section boundaries (N.NN).
+3. For sections still above the limit, apply token-count splitting with a
+   50-token overlap — never mid-sentence.
+4. TableBlock instances are kept atomic regardless of size.
+
+Chunk metadata (article_number, section_number, article_title, page_number,
+chunk_index, is_table) is attached at this stage and flows into the embed and
+store stages.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from classify import ClassifiedDocument
+from extract import TableBlock, TableRows, TextBlock
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+MAX_CHUNK_TOKENS: int = 500
+OVERLAP_TOKENS: int = 50
+CHARS_PER_TOKEN: int = 4  # English-text approximation (~4 chars per token)
+
+_MAX_CHARS = MAX_CHUNK_TOKENS * CHARS_PER_TOKEN   # 2 000
+_OVERLAP_CHARS = OVERLAP_TOKENS * CHARS_PER_TOKEN  # 200
+
+# ─── Regex patterns ───────────────────────────────────────────────────────────
+
+# EPSCA article headings: "ARTICLE 12 — OVERTIME", "ARTICLE 3", "ARTICLE 1 – SCOPE"
+# Accepts em-dash (—), en-dash (–), and plain hyphen (-) as separators.
+_ARTICLE_RE = re.compile(
+    r"^ARTICLE\s+(\d+)\s*(?:[—–-]\s*(.+))?$",
+    re.IGNORECASE,
+)
+
+# Section/clause numbers at the start of a line: "1.01", "12.03", "4.02a"
+_SECTION_RE = re.compile(r"^(\d+\.\d+[a-z]?)\s")
+
+# Sentence-ending punctuation followed by whitespace or end-of-string
+_SENTENCE_END_RE = re.compile(r"[.!?](?=\s|$)")
+
+# ─── Data structures ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """A single chunk produced by the chunk stage, ready for embedding."""
+
+    text: str
+    page_number: int
+    is_table: bool
+    article_number: str | None
+    section_number: str | None
+    article_title: str | None
+    chunk_index: int
+
+
+# ─── Internal helpers ─────────────────────────────────────────────────────────
+
+
+def _count_tokens(text: str) -> int:
+    """Approximate token count using a 4-chars-per-token heuristic."""
+    return len(text) // CHARS_PER_TOKEN
+
+
+def _format_table(rows: TableRows) -> str:
+    """Serialise table rows to pipe-delimited text for embedding."""
+    lines: list[str] = []
+    for row in rows:
+        cells = [str(cell or "").strip() for cell in row]
+        lines.append(" | ".join(cells))
+    return "\n".join(lines)
+
+
+def _find_sentence_boundary(text: str, near: int) -> int:
+    """
+    Return the index just after the last sentence-ending punctuation at or
+    before `near`.  Falls back to the last whitespace, then to `near` itself.
+    """
+    # Search backward up to 300 chars from `near`
+    search_start = max(0, near - 300)
+    segment = text[search_start:near]
+
+    # Find the last sentence-ending match in the segment
+    last_match: re.Match[str] | None = None
+    for m in _SENTENCE_END_RE.finditer(segment):
+        last_match = m
+
+    if last_match is not None:
+        return search_start + last_match.end()
+
+    # Fall back to last whitespace
+    for i in range(near, max(search_start, 0), -1):
+        if text[i - 1] == " ":
+            return i
+
+    return near  # Last resort: split at `near` exactly
+
+
+def _split_with_overlap(
+    text: str,
+    page_number: int,
+    article_number: str | None,
+    article_title: str | None,
+    section_number: str | None,
+) -> list[Chunk]:
+    """
+    Split oversized section text into chunks of ≤ MAX_CHUNK_TOKENS with a
+    50-token overlap between consecutive chunks.  Splits are made at sentence
+    boundaries where possible, never mid-sentence.
+    """
+    raw: list[Chunk] = []
+    remaining = text
+
+    while len(remaining) > _MAX_CHARS:
+        split_pos = _find_sentence_boundary(remaining, _MAX_CHARS)
+
+        # Guard against degenerate cases (no boundary found near the limit)
+        if split_pos <= 0:
+            split_pos = _MAX_CHARS
+
+        chunk_text = remaining[:split_pos].strip()
+        if chunk_text:
+            raw.append(
+                Chunk(
+                    text=chunk_text,
+                    page_number=page_number,
+                    is_table=False,
+                    article_number=article_number,
+                    section_number=section_number,
+                    article_title=article_title,
+                    chunk_index=0,  # reassigned in chunk_document
+                )
+            )
+
+        # Overlap: next chunk starts 50 tokens before the split point
+        overlap_start = max(0, split_pos - _OVERLAP_CHARS)
+        # Advance to the next word boundary so the overlap starts cleanly
+        while overlap_start < split_pos and remaining[overlap_start] not in (" ", "\n"):
+            overlap_start += 1
+        overlap_start = min(overlap_start + 1, split_pos)
+
+        next_remaining = remaining[overlap_start:].lstrip()
+
+        # Safety: if the candidate next_remaining made no progress (e.g. the
+        # word-boundary walk saturated at split_pos), advance past split_pos
+        # to avoid silently dropping content.
+        if len(next_remaining) >= len(remaining):
+            remaining = remaining[split_pos:].lstrip()
+        else:
+            remaining = next_remaining
+
+    if remaining.strip():
+        raw.append(
+            Chunk(
+                text=remaining.strip(),
+                page_number=page_number,
+                is_table=False,
+                article_number=article_number,
+                section_number=section_number,
+                article_title=article_title,
+                chunk_index=0,
+            )
+        )
+
+    return raw
+
+
+def _split_into_sections(
+    lines: list[tuple[str, int]],
+) -> list[tuple[str | None, list[tuple[str, int]]]]:
+    """
+    Group article lines by section number.
+
+    Returns a list of (section_number, lines) pairs.  Lines before the first
+    section number are grouped under section_number=None (the article preamble /
+    heading itself).
+    """
+    groups: list[tuple[str | None, list[tuple[str, int]]]] = []
+    current_section: str | None = None
+    current_lines: list[tuple[str, int]] = []
+
+    for line, page in lines:
+        match = _SECTION_RE.match(line)
+        if match:
+            if current_lines:
+                groups.append((current_section, current_lines))
+            current_section = match.group(1)
+            current_lines = [(line, page)]
+        else:
+            current_lines.append((line, page))
+
+    if current_lines:
+        groups.append((current_section, current_lines))
+
+    return groups
+
+
+def _process_article(
+    lines: list[tuple[str, int]],
+    article_number: str | None,
+    article_title: str | None,
+    out: list[Chunk],
+) -> None:
+    """
+    Convert accumulated article lines into one or more Chunks and append to
+    `out`.
+
+    Strategy:
+    - If the full article text fits within MAX_CHUNK_TOKENS → one chunk.
+    - Otherwise split at section boundaries; apply token-count fallback with
+      overlap for any section that still exceeds the limit.
+    """
+    if not lines:
+        return
+
+    full_text = "\n".join(line for line, _ in lines).strip()
+    if not full_text:
+        return
+
+    page_number = lines[0][1]
+
+    # ── Fast path: entire article fits in one chunk ───────────────────────────
+    if _count_tokens(full_text) <= MAX_CHUNK_TOKENS:
+        out.append(
+            Chunk(
+                text=full_text,
+                page_number=page_number,
+                is_table=False,
+                article_number=article_number,
+                section_number=None,
+                article_title=article_title,
+                chunk_index=0,
+            )
+        )
+        return
+
+    # ── Split at section boundaries ───────────────────────────────────────────
+    sections = _split_into_sections(lines)
+
+    for section_number, section_lines in sections:
+        section_text = "\n".join(line for line, _ in section_lines).strip()
+        if not section_text:
+            continue
+
+        s_page = section_lines[0][1]
+
+        if _count_tokens(section_text) <= MAX_CHUNK_TOKENS:
+            out.append(
+                Chunk(
+                    text=section_text,
+                    page_number=s_page,
+                    is_table=False,
+                    article_number=article_number,
+                    section_number=section_number,
+                    article_title=article_title,
+                    chunk_index=0,
+                )
+            )
+        else:
+            # Token-count fallback with overlap
+            out.extend(
+                _split_with_overlap(
+                    text=section_text,
+                    page_number=s_page,
+                    article_number=article_number,
+                    article_title=article_title,
+                    section_number=section_number,
+                )
+            )
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+
+def chunk_document(doc: ClassifiedDocument) -> list[Chunk]:
+    """
+    Split a ClassifiedDocument into structure-aware Chunks.
+
+    Processing order mirrors the block order from extract.py:
+    - TableBlocks → one atomic Chunk each (is_table=True).
+    - TextBlocks  → accumulated per-article, then split as described above.
+
+    Chunk indices are assigned sequentially after all chunks are collected.
+
+    Args:
+        doc: A ClassifiedDocument produced by classify.py.
+
+    Returns:
+        A list of Chunks in document order with sequential chunk_index values.
+    """
+    raw: list[Chunk] = []
+
+    # Running article context shared between text and table blocks
+    current_article_number: str | None = None
+    current_article_title: str | None = None
+
+    # Lines accumulated for the current article: (text, page_number)
+    article_lines: list[tuple[str, int]] = []
+
+    def _flush() -> None:
+        nonlocal article_lines
+        _process_article(article_lines, current_article_number, current_article_title, raw)
+        article_lines = []  # replace, never mutate
+
+    for block in doc.extracted.blocks:
+        if isinstance(block, TableBlock):
+            # Flush pending article text before emitting the table chunk
+            _flush()
+            table_text = _format_table(block.rows)
+            raw.append(
+                Chunk(
+                    text=table_text,
+                    page_number=block.page_number,
+                    is_table=True,
+                    article_number=current_article_number,
+                    article_title=current_article_title,
+                    section_number=None,
+                    chunk_index=0,
+                )
+            )
+
+        elif isinstance(block, TextBlock):
+            for raw_line in block.text.split("\n"):
+                line = raw_line.strip()
+                if not line:
+                    continue
+
+                article_match = _ARTICLE_RE.match(line)
+                if article_match:
+                    # Flush the previous article before starting the new one
+                    _flush()
+                    num_str = article_match.group(1)
+                    current_article_number = f"Article {num_str}"
+                    title = article_match.group(2)
+                    current_article_title = title.strip() if title else None
+
+                # Always add the line (including the heading itself) so the
+                # heading text appears at the top of the first chunk for context
+                article_lines.append((line, block.page_number))
+
+    # Flush the final article
+    _flush()
+
+    # Assign sequential chunk_index values (Chunk is frozen, so rebuild)
+    return [
+        Chunk(
+            text=c.text,
+            page_number=c.page_number,
+            is_table=c.is_table,
+            article_number=c.article_number,
+            section_number=c.section_number,
+            article_title=c.article_title,
+            chunk_index=i,
+        )
+        for i, c in enumerate(raw)
+    ]

--- a/services/ingestion/classify.py
+++ b/services/ingestion/classify.py
@@ -1,0 +1,117 @@
+"""
+Stage 3: Classify — assign document metadata from corpus_manifest.
+
+Matches each ExtractedDocument to its corpus_manifest entry by source filename
+and returns a ClassifiedDocument carrying the manifest metadata alongside the
+extracted content.  The metadata is used by all downstream stages (chunk, embed,
+store) to populate the Qdrant payload and the PostgreSQL documents table.
+"""
+
+from __future__ import annotations
+
+import datetime
+import functools
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from extract import ExtractedDocument
+
+_HERE = Path(__file__).parent
+CORPUS_MANIFEST = _HERE / "corpus_manifest.yaml"
+
+
+@dataclass(frozen=True)
+class DocumentMetadata:
+    """Manifest-derived metadata for a single corpus document."""
+
+    union_name: str
+    document_type: str
+    agreement_scope: str | None
+    effective_date: str
+    expiry_date: str | None
+
+
+@dataclass
+class ClassifiedDocument:
+    """An ExtractedDocument paired with its corpus_manifest metadata."""
+
+    extracted: ExtractedDocument
+    metadata: DocumentMetadata
+
+
+def _to_date_str(value: object) -> str:
+    """
+    Normalise a value from yaml.safe_load to an ISO-8601 date string.
+
+    PyYAML's safe_load parses bare YAML dates (e.g. ``2025-05-01``) as
+    ``datetime.date`` objects.  Quoted strings pass through unchanged.
+    This function normalises both representations to a consistent ``str``
+    at the system boundary, so downstream stages receive a typed string
+    regardless of YAML quoting style.
+    """
+    if isinstance(value, datetime.date):
+        return value.isoformat()
+    return str(value)
+
+
+@functools.lru_cache(maxsize=8)
+def _load_manifest_entries(manifest_path: Path) -> list[dict[str, object]]:
+    """
+    Load and cache manifest entries from a corpus_manifest.yaml file.
+
+    Caching avoids repeated file I/O and YAML parsing when ``classify`` is
+    called once per document in a pipeline run against a fixed manifest.
+    The cache is keyed on the absolute path, so tests using isolated
+    ``tmp_path`` manifests each get their own cache entry.
+    """
+    with manifest_path.open() as f:
+        data = yaml.safe_load(f) or {}
+    return list(data.get("documents", []))
+
+
+def classify(
+    doc: ExtractedDocument,
+    manifest_path: Path = CORPUS_MANIFEST,
+) -> ClassifiedDocument:
+    """
+    Match an extracted document to its corpus_manifest entry by filename.
+
+    Args:
+        doc:           ExtractedDocument produced by extract.py.
+        manifest_path: Path to corpus_manifest.yaml (defaults to the file
+                       adjacent to this module).
+
+    Returns:
+        ClassifiedDocument with metadata drawn from the matching manifest entry.
+
+    Raises:
+        ValueError: If no manifest entry's source_filename matches
+                    doc.source_path.name.
+    """
+    entries = _load_manifest_entries(manifest_path)
+    filename = doc.source_path.name
+
+    for entry in entries:
+        if entry.get("source_filename") == filename:
+            expiry_raw = entry.get("expiry_date")
+            return ClassifiedDocument(
+                extracted=doc,
+                metadata=DocumentMetadata(
+                    union_name=str(entry["union_name"]),
+                    document_type=str(entry["document_type"]),
+                    agreement_scope=(
+                        str(entry["agreement_scope"])
+                        if entry.get("agreement_scope") is not None
+                        else None
+                    ),
+                    effective_date=_to_date_str(entry["effective_date"]),
+                    expiry_date=_to_date_str(expiry_raw) if expiry_raw is not None else None,
+                ),
+            )
+
+    raise ValueError(
+        f"No manifest entry found for '{filename}'. "
+        f"Add it to {manifest_path.name} before running classify."
+    )

--- a/services/ingestion/requirements.txt
+++ b/services/ingestion/requirements.txt
@@ -8,5 +8,6 @@ tqdm>=4.66.0
 # Dev / test
 ruff>=0.4.0
 mypy>=1.10.0
+types-PyYAML>=6.0.0
 pytest>=8.2.0
 pytest-asyncio>=0.23.0

--- a/services/ingestion/run_pipeline.py
+++ b/services/ingestion/run_pipeline.py
@@ -32,6 +32,10 @@ async def run_stage(stage: str) -> None:
             logger.info("[%s] %s — %s", r.status.value.upper(), r.source_filename, detail)
     elif stage == "extract":
         logger.info("Extract stage not yet wired to orchestrator — run extract.py directly")
+    elif stage == "classify":
+        logger.info("Classify stage not yet wired to orchestrator — use classify.py directly")
+    elif stage == "chunk":
+        logger.info("Chunk stage not yet wired to orchestrator — use chunk.py directly")
     else:
         logger.warning("Stage '%s' not yet implemented", stage)
 

--- a/services/ingestion/tests/test_chunk.py
+++ b/services/ingestion/tests/test_chunk.py
@@ -1,0 +1,382 @@
+"""Tests for chunk.py — Stage 4 of the ingestion pipeline."""
+
+from chunk import CHARS_PER_TOKEN, MAX_CHUNK_TOKENS, chunk_document
+from pathlib import Path
+
+import pytest
+
+from classify import ClassifiedDocument, DocumentMetadata
+from extract import ExtractedDocument, TableBlock, TextBlock
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _make_metadata() -> DocumentMetadata:
+    return DocumentMetadata(
+        union_name="IBEW",
+        document_type="primary_ca",
+        agreement_scope="generation",
+        effective_date="2025-05-01",
+        expiry_date="2030-04-30",
+    )
+
+
+def _make_doc(blocks: list, page_count: int = 1) -> ClassifiedDocument:
+    extracted = ExtractedDocument(
+        source_path=Path("test.pdf"),
+        blocks=blocks,
+        page_count=page_count,
+    )
+    return ClassifiedDocument(extracted=extracted, metadata=_make_metadata())
+
+
+def _long_text(tokens: int) -> str:
+    """Return text that approximates the given token count."""
+    char_count = tokens * CHARS_PER_TOKEN
+    # "word " is 5 chars; pad to exact char count
+    words = "word " * (char_count // 5)
+    return words[:char_count]
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+class TestEmptyDocument:
+    def test_empty_blocks_produces_no_chunks(self) -> None:
+        chunks = chunk_document(_make_doc([]))
+        assert chunks == []
+
+    def test_whitespace_only_text_produces_no_chunks(self) -> None:
+        block = TextBlock(text="   \n\n\t  \n", page_number=1)
+        chunks = chunk_document(_make_doc([block]))
+        assert chunks == []
+
+
+class TestTableChunks:
+    def test_table_block_produces_one_chunk(self) -> None:
+        rows = (("Classification", "Rate"), ("Journeyperson", "$45.00"))
+        block = TableBlock(rows=rows, page_number=3)
+        chunks = chunk_document(_make_doc([block]))
+        assert len(chunks) == 1
+
+    def test_table_chunk_is_flagged(self) -> None:
+        rows = (("Classification", "Rate"), ("Journeyperson", "$45.00"))
+        block = TableBlock(rows=rows, page_number=1)
+        chunks = chunk_document(_make_doc([block]))
+        assert chunks[0].is_table is True
+
+    def test_table_chunk_preserves_page_number(self) -> None:
+        rows = (("A", "B"),)
+        block = TableBlock(rows=rows, page_number=7)
+        chunks = chunk_document(_make_doc([block]))
+        assert chunks[0].page_number == 7
+
+    def test_table_chunk_contains_row_data(self) -> None:
+        rows = (
+            ("Classification", "Hourly Rate"),
+            ("Journeyperson", "$45.00"),
+            ("Apprentice", "$36.00"),
+        )
+        block = TableBlock(rows=rows, page_number=1)
+        chunks = chunk_document(_make_doc([block]))
+        assert "Journeyperson" in chunks[0].text
+        assert "$45.00" in chunks[0].text
+
+    def test_large_table_is_atomic(self) -> None:
+        """A table that exceeds the token limit must never be split."""
+        rows = tuple(
+            tuple(f"cell_{r}_{c}" for c in range(10))
+            for r in range(60)
+        )
+        block = TableBlock(rows=rows, page_number=1)
+        chunks = chunk_document(_make_doc([block]))
+        assert len(chunks) == 1
+        assert chunks[0].is_table is True
+
+    def test_table_with_none_cells_handled(self) -> None:
+        rows = ((None, "Rate"), ("Journeyperson", None))
+        block = TableBlock(rows=rows, page_number=1)
+        chunks = chunk_document(_make_doc([block]))
+        assert len(chunks) == 1
+        assert "Journeyperson" in chunks[0].text
+
+    def test_multiple_tables_produce_multiple_chunks(self) -> None:
+        rows = (("A", "B"),)
+        blocks = [
+            TableBlock(rows=rows, page_number=1),
+            TableBlock(rows=rows, page_number=2),
+        ]
+        chunks = chunk_document(_make_doc(blocks))
+        table_chunks = [c for c in chunks if c.is_table]
+        assert len(table_chunks) == 2
+
+
+class TestArticleBoundaryDetection:
+    def test_article_heading_starts_new_chunk(self) -> None:
+        """Two articles → at least two chunks when each fits in the token limit."""
+        text = (
+            "ARTICLE 1 — RECOGNITION\n"
+            "1.01 The Company recognizes the Union.\n"
+            "ARTICLE 2 — UNION SECURITY\n"
+            "2.01 All employees shall be members."
+        )
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert len(chunks) >= 2
+
+    def test_article_number_parsed_from_heading(self) -> None:
+        text = "ARTICLE 12 — OVERTIME\n12.01 Overtime pay applies."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert any(c.article_number == "Article 12" for c in chunks)
+
+    def test_article_title_parsed_from_heading(self) -> None:
+        text = "ARTICLE 5 — WAGES AND BENEFITS\n5.01 Wage rates are set forth."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        art5 = [c for c in chunks if c.article_number == "Article 5"]
+        assert any(c.article_title == "WAGES AND BENEFITS" for c in art5)
+
+    def test_heading_without_title_sets_article_number(self) -> None:
+        text = "ARTICLE 3\n3.01 Some clause text."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert any(c.article_number == "Article 3" for c in chunks)
+
+    def test_heading_without_title_has_none_article_title(self) -> None:
+        text = "ARTICLE 3\n3.01 Some clause text."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        art3 = [c for c in chunks if c.article_number == "Article 3"]
+        assert all(c.article_title is None for c in art3)
+
+    def test_heading_with_em_dash_parsed(self) -> None:
+        """Standard EPSCA format uses the em-dash (—)."""
+        text = "ARTICLE 1 — RECOGNITION\n1.01 Recognized."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert any(c.article_number == "Article 1" for c in chunks)
+
+    def test_heading_with_en_dash_parsed(self) -> None:
+        text = "ARTICLE 2 – SCOPE\n2.01 Applies to all trades."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert any(c.article_number == "Article 2" for c in chunks)
+
+    def test_heading_with_hyphen_parsed(self) -> None:
+        text = "ARTICLE 4 - SENIORITY\n4.01 Seniority applies."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert any(c.article_number == "Article 4" for c in chunks)
+
+    def test_preamble_before_first_article_becomes_chunk(self) -> None:
+        text = (
+            "COLLECTIVE AGREEMENT\n"
+            "Between the Employer and the Union\n"
+            "ARTICLE 1 — RECOGNITION\n"
+            "1.01 The Company recognizes the Union."
+        )
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        preamble = [c for c in chunks if c.article_number is None and not c.is_table]
+        assert len(preamble) >= 1
+
+    def test_preamble_chunk_contains_preamble_text(self) -> None:
+        text = (
+            "COLLECTIVE AGREEMENT\n"
+            "ARTICLE 1 — RECOGNITION\n"
+            "1.01 The Company recognizes the Union."
+        )
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        preamble = [c for c in chunks if c.article_number is None and not c.is_table]
+        assert any("COLLECTIVE AGREEMENT" in c.text for c in preamble)
+
+    def test_article_spanning_two_pages(self) -> None:
+        """Article beginning on page 1 continues on page 2."""
+        page1 = TextBlock(text="ARTICLE 1 — RECOGNITION\n1.01 The Company.", page_number=1)
+        page2 = TextBlock(text="1.02 The Union agrees.", page_number=2)
+        chunks = chunk_document(_make_doc([page1, page2]))
+        art1 = [c for c in chunks if c.article_number == "Article 1"]
+        assert len(art1) >= 1
+
+
+class TestSectionBoundaries:
+    def test_small_article_stays_one_chunk(self) -> None:
+        """Article within token limit → single chunk even with multiple sections."""
+        text = (
+            "ARTICLE 1 — RECOGNITION\n"
+            "1.01 Short clause.\n"
+            "1.02 Another short clause."
+        )
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        art1 = [c for c in chunks if c.article_number == "Article 1"]
+        assert len(art1) == 1
+
+    def test_small_article_chunk_has_no_section_number(self) -> None:
+        """One-chunk article covers the whole article, so section_number is None."""
+        text = "ARTICLE 1 — RECOGNITION\n1.01 Short.\n1.02 Also short."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        art1 = [c for c in chunks if c.article_number == "Article 1"]
+        assert len(art1) == 1
+        assert art1[0].section_number is None
+
+    def test_oversized_article_splits_at_section_boundaries(self) -> None:
+        """Article exceeding token limit is split at section lines."""
+        section_body = _long_text(280)  # 280 tokens per section
+        text = (
+            "ARTICLE 1 — WAGES\n"
+            f"1.01 {section_body}\n"
+            f"1.02 {section_body}"
+        )
+        # total ≈ 5 (heading) + 280 + 280 = 565 tokens > MAX (500) → split
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        art1 = [c for c in chunks if c.article_number == "Article 1"]
+        assert len(art1) >= 2
+
+    def test_section_number_attached_after_split(self) -> None:
+        """After splitting, each section chunk carries its section number."""
+        section_body = _long_text(280)
+        text = (
+            "ARTICLE 1 — WAGES\n"
+            f"1.01 {section_body}\n"
+            f"1.02 {section_body}"
+        )
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        section_numbers = {c.section_number for c in chunks if c.section_number}
+        assert "1.01" in section_numbers or "1.02" in section_numbers
+
+    def test_section_number_none_for_unsplit_article(self) -> None:
+        """When article fits in limit and has no split, section_number stays None."""
+        text = "ARTICLE 2 — SCOPE\n2.01 Short.\n2.02 Also short."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        art2 = [c for c in chunks if c.article_number == "Article 2"]
+        assert all(c.section_number is None for c in art2)
+
+
+class TestChunkIndex:
+    def test_chunk_index_starts_at_zero(self) -> None:
+        text = "ARTICLE 1 — RECOGNITION\n1.01 Short clause."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert chunks[0].chunk_index == 0
+
+    def test_chunk_index_is_sequential(self) -> None:
+        text = (
+            "ARTICLE 1 — RECOGNITION\n1.01 First.\n"
+            "ARTICLE 2 — SCOPE\n2.01 Second."
+        )
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        indices = [c.chunk_index for c in chunks]
+        assert indices == list(range(len(chunks)))
+
+    def test_table_and_text_chunks_share_sequential_index(self) -> None:
+        rows = (("A", "B"),)
+        table = TableBlock(rows=rows, page_number=1)
+        text = TextBlock(text="ARTICLE 1 — SCOPE\n1.01 Clause.", page_number=2)
+        chunks = chunk_document(_make_doc([table, text]))
+        indices = [c.chunk_index for c in chunks]
+        assert indices == list(range(len(chunks)))
+
+    def test_many_chunks_have_contiguous_indices(self) -> None:
+        section_body = _long_text(280)
+        text = (
+            "ARTICLE 1 — WAGES\n"
+            f"1.01 {section_body}\n"
+            f"1.02 {section_body}\n"
+            "ARTICLE 2 — SCOPE\n"
+            "2.01 Short."
+        )
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        indices = [c.chunk_index for c in chunks]
+        assert indices == list(range(len(chunks)))
+
+
+class TestPageNumbers:
+    def test_text_chunk_carries_block_page_number(self) -> None:
+        text = "ARTICLE 1 — RECOGNITION\n1.01 Clause."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=5)]))
+        text_chunks = [c for c in chunks if not c.is_table]
+        assert all(c.page_number == 5 for c in text_chunks)
+
+    def test_table_chunk_carries_block_page_number(self) -> None:
+        rows = (("A", "B"),)
+        chunks = chunk_document(_make_doc([TableBlock(rows=rows, page_number=12)]))
+        assert chunks[0].page_number == 12
+
+    def test_cross_page_article_first_chunk_has_heading_page(self) -> None:
+        page1 = TextBlock(text="ARTICLE 3 — OVERTIME\n3.01 Clause.", page_number=4)
+        page2 = TextBlock(text="3.02 Another clause.", page_number=5)
+        chunks = chunk_document(_make_doc([page1, page2]))
+        art3 = [c for c in chunks if c.article_number == "Article 3"]
+        # The first article chunk should start on page 4 (where the heading is)
+        assert art3[0].page_number == 4
+
+
+class TestTableArticleContext:
+    def test_table_inherits_current_article_number(self) -> None:
+        text_block = TextBlock(
+            text="ARTICLE 8 — WAGES\n8.01 See attached schedule.",
+            page_number=1,
+        )
+        rows = (("Classification", "Rate"), ("Journeyperson", "$45.00"))
+        table_block = TableBlock(rows=rows, page_number=2)
+        chunks = chunk_document(_make_doc([text_block, table_block]))
+        table_chunks = [c for c in chunks if c.is_table]
+        assert len(table_chunks) == 1
+        assert table_chunks[0].article_number == "Article 8"
+
+    def test_table_before_any_article_has_no_article_number(self) -> None:
+        rows = (("A", "B"),)
+        chunks = chunk_document(_make_doc([TableBlock(rows=rows, page_number=1)]))
+        assert chunks[0].article_number is None
+
+    def test_table_inherits_article_title(self) -> None:
+        text_block = TextBlock(
+            text="ARTICLE 8 — WAGES\n8.01 See the schedule.",
+            page_number=1,
+        )
+        rows = (("Classification", "Rate"),)
+        table_block = TableBlock(rows=rows, page_number=2)
+        chunks = chunk_document(_make_doc([text_block, table_block]))
+        table_chunks = [c for c in chunks if c.is_table]
+        assert table_chunks[0].article_title == "WAGES"
+
+
+class TestTokenCountFallback:
+    def test_oversized_section_produces_multiple_chunks(self) -> None:
+        """Section text exceeding MAX_CHUNK_TOKENS is split into sub-chunks."""
+        long_body = _long_text(MAX_CHUNK_TOKENS + 100)
+        text = f"ARTICLE 1 — WAGES\n1.01 {long_body}"
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert len(chunks) >= 2
+
+    def test_split_chunks_share_article_number(self) -> None:
+        long_body = _long_text(MAX_CHUNK_TOKENS + 100)
+        text = f"ARTICLE 2 — SCOPE\n2.01 {long_body}"
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        for chunk in chunks:
+            if not chunk.is_table:
+                assert chunk.article_number == "Article 2"
+
+    def test_split_chunks_share_section_number(self) -> None:
+        long_body = _long_text(MAX_CHUNK_TOKENS + 100)
+        text = f"ARTICLE 2 — SCOPE\n2.01 {long_body}"
+        # Make the article long enough to split at section boundary
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        non_table = [c for c in chunks if not c.is_table]
+        # section_number is set when sections are split out; at least two sub-chunks
+        assert len(non_table) >= 2
+
+    def test_no_chunk_exceeds_double_max_tokens(self) -> None:
+        """Even with overlap, no single chunk should be more than 2× the limit."""
+        long_body = _long_text(MAX_CHUNK_TOKENS * 5)
+        text = f"ARTICLE 1 — WAGES\n1.01 {long_body}"
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        max_allowed = MAX_CHUNK_TOKENS * CHARS_PER_TOKEN * 2
+        for chunk in chunks:
+            assert len(chunk.text) <= max_allowed
+
+
+class TestChunkDataclass:
+    def test_chunk_is_frozen(self) -> None:
+        """Chunk must be immutable."""
+        text = "ARTICLE 1 — SCOPE\n1.01 Short."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        assert len(chunks) >= 1
+        with pytest.raises((TypeError, AttributeError)):
+            chunks[0].text = "mutated"  # type: ignore[misc]
+
+    def test_chunk_is_table_false_for_text(self) -> None:
+        text = "ARTICLE 1 — SCOPE\n1.01 Short."
+        chunks = chunk_document(_make_doc([TextBlock(text=text, page_number=1)]))
+        text_chunks = [c for c in chunks if not c.is_table]
+        assert len(text_chunks) >= 1
+        assert all(c.is_table is False for c in text_chunks)

--- a/services/ingestion/tests/test_classify.py
+++ b/services/ingestion/tests/test_classify.py
@@ -1,0 +1,226 @@
+"""Tests for classify.py — Stage 3 of the ingestion pipeline."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from classify import ClassifiedDocument, DocumentMetadata, classify
+from extract import ExtractedDocument
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _make_manifest(entries: list[dict]) -> dict:
+    return {"documents": entries}
+
+
+def _manifest_entry(
+    source_filename: str,
+    union_name: str = "IBEW",
+    document_type: str = "primary_ca",
+    agreement_scope: str | None = "generation",
+    effective_date: str = "2025-05-01",
+    expiry_date: str | None = "2030-04-30",
+) -> dict:
+    return {
+        "union_name": union_name,
+        "document_type": document_type,
+        "agreement_scope": agreement_scope,
+        "source_filename": source_filename,
+        "effective_date": effective_date,
+        "expiry_date": expiry_date,
+    }
+
+
+def _write_manifest(tmp_path: Path, entries: list[dict]) -> Path:
+    p = tmp_path / "manifest.yaml"
+    p.write_text(yaml.dump(_make_manifest(entries)))
+    return p
+
+
+def _make_extracted(filename: str, tmp_path: Path) -> ExtractedDocument:
+    pdf = tmp_path / filename
+    pdf.write_bytes(b"%PDF-1.4 fake")
+    return ExtractedDocument(source_path=pdf)
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+class TestClassifyReturnType:
+    def test_returns_classified_document(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path, [_manifest_entry("test.pdf")])
+        doc = _make_extracted("test.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert isinstance(result, ClassifiedDocument)
+
+    def test_extracted_document_is_preserved(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path, [_manifest_entry("test.pdf")])
+        doc = _make_extracted("test.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.extracted is doc
+
+    def test_metadata_is_document_metadata(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path, [_manifest_entry("test.pdf")])
+        doc = _make_extracted("test.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert isinstance(result.metadata, DocumentMetadata)
+
+
+class TestMetadataFields:
+    def test_union_name_assigned(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path, [_manifest_entry("sm.pdf", union_name="Sheet Metal")]
+        )
+        doc = _make_extracted("sm.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.union_name == "Sheet Metal"
+
+    def test_document_type_primary_ca(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path, [_manifest_entry("ca.pdf", document_type="primary_ca")]
+        )
+        doc = _make_extracted("ca.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.document_type == "primary_ca"
+
+    def test_document_type_nuclear_pa(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path, [_manifest_entry("npa.pdf", document_type="nuclear_pa")]
+        )
+        doc = _make_extracted("npa.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.document_type == "nuclear_pa"
+
+    def test_document_type_wage_schedule(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path,
+            [_manifest_entry("wage.pdf", document_type="wage_schedule", expiry_date=None)],
+        )
+        doc = _make_extracted("wage.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.document_type == "wage_schedule"
+
+    def test_agreement_scope_generation(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path, [_manifest_entry("ibew.pdf", agreement_scope="generation")]
+        )
+        doc = _make_extracted("ibew.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.agreement_scope == "generation"
+
+    def test_agreement_scope_none_for_unions_without_scope(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path, [_manifest_entry("sm.pdf", agreement_scope=None)]
+        )
+        doc = _make_extracted("sm.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.agreement_scope is None
+
+    def test_effective_date_assigned(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path, [_manifest_entry("test.pdf", effective_date="2025-05-01")]
+        )
+        doc = _make_extracted("test.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.effective_date == "2025-05-01"
+
+    def test_expiry_date_assigned(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path, [_manifest_entry("test.pdf", expiry_date="2030-04-30")]
+        )
+        doc = _make_extracted("test.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.expiry_date == "2030-04-30"
+
+    def test_expiry_date_none_for_wage_schedules(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path,
+            [_manifest_entry("wage.pdf", document_type="wage_schedule", expiry_date=None)],
+        )
+        doc = _make_extracted("wage.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.expiry_date is None
+
+
+class TestFilenameMatching:
+    def test_matches_by_source_filename(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path, [_manifest_entry("IBEW Generation- 2025-2030 Collective Agreement.pdf")]
+        )
+        doc = _make_extracted("IBEW Generation- 2025-2030 Collective Agreement.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.union_name == "IBEW"
+
+    def test_matches_regardless_of_parent_directory(self, tmp_path: Path) -> None:
+        """File in a subdirectory matches by filename only."""
+        manifest_path = _write_manifest(tmp_path, [_manifest_entry("match.pdf")])
+        subdir = tmp_path / "ibew" / "primary_ca"
+        subdir.mkdir(parents=True)
+        pdf = subdir / "match.pdf"
+        pdf.write_bytes(b"%PDF fake")
+        doc = ExtractedDocument(source_path=pdf)
+        result = classify(doc, manifest_path)
+        assert result.metadata.union_name == "IBEW"
+
+    def test_selects_correct_entry_from_multiple(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path,
+            [
+                _manifest_entry("ibew.pdf", union_name="IBEW"),
+                _manifest_entry("sm.pdf", union_name="Sheet Metal"),
+                _manifest_entry("ua.pdf", union_name="United Association"),
+            ],
+        )
+        doc = _make_extracted("sm.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.union_name == "Sheet Metal"
+
+
+class TestErrorHandling:
+    def test_raises_value_error_for_unknown_document(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path, [_manifest_entry("known.pdf")])
+        doc = _make_extracted("unknown.pdf", tmp_path)
+        with pytest.raises(ValueError, match="unknown.pdf"):
+            classify(doc, manifest_path)
+
+    def test_error_message_includes_filename(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path, [])
+        doc = _make_extracted("missing-doc.pdf", tmp_path)
+        with pytest.raises(ValueError, match="missing-doc.pdf"):
+            classify(doc, manifest_path)
+
+
+class TestYamlDateNormalisation:
+    def test_bare_yaml_date_normalised_to_iso_string(self, tmp_path: Path) -> None:
+        """PyYAML parses unquoted YYYY-MM-DD as datetime.date; we must coerce to str."""
+        # Write manifest with unquoted dates so PyYAML produces datetime.date objects
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(
+            "documents:\n"
+            "  - union_name: IBEW\n"
+            "    document_type: primary_ca\n"
+            "    agreement_scope: generation\n"
+            "    source_filename: date-test.pdf\n"
+            "    effective_date: 2025-05-01\n"  # bare date → datetime.date
+            "    expiry_date: 2030-04-30\n"      # bare date → datetime.date
+        )
+        doc = _make_extracted("date-test.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.effective_date == "2025-05-01"
+        assert isinstance(result.metadata.effective_date, str)
+
+    def test_bare_yaml_expiry_date_normalised(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest2.yaml"
+        manifest_path.write_text(
+            "documents:\n"
+            "  - union_name: Sheet Metal\n"
+            "    document_type: primary_ca\n"
+            "    agreement_scope: null\n"
+            "    source_filename: sm-date.pdf\n"
+            "    effective_date: 2025-05-01\n"
+            "    expiry_date: 2030-04-30\n"
+        )
+        doc = _make_extracted("sm-date.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.expiry_date == "2030-04-30"
+        assert isinstance(result.metadata.expiry_date, str)


### PR DESCRIPTION
## Summary

- **classify.py** (Stage 3) — matches `ExtractedDocument` to `corpus_manifest.yaml` entry by `source_filename`, returns `ClassifiedDocument(extracted, metadata)`. Normalises PyYAML bare-date objects to ISO strings; caches manifest loading via `lru_cache`.
- **chunk.py** (Stage 4) — structure-aware chunking: article-boundary → section-boundary → 50-token-overlap fallback. Tables atomic. Sequential `chunk_index`. All Qdrant payload metadata attached per chunk.
- 60 new tests (98 total); ruff clean; all 4 HIGH issues from code review addressed.

Closes #12

## Test plan

- [ ] `python3 -m pytest` — 98 passed, 0 failed
- [ ] `python3 -m ruff check services/ingestion/` — no errors
- [ ] Verify bare-date YAML normalisation test passes (`TestYamlDateNormalisation`)
- [ ] Verify table atomicity test passes even for large tables (`test_large_table_is_atomic`)
- [ ] Verify section-split test produces ≥ 2 chunks for oversized articles (`test_oversized_article_splits_at_section_boundaries`)