### PR TITLE
feat(ingestion): build embed, store, and pipeline orchestrator

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -36,7 +36,7 @@ Goal: End-to-end pipeline validated against 3 unions (IBEW Generation, Sheet Met
 
 | # | type | status | title |
 |---|------|--------|-------|
-| [#11](https://github.com/BoilerHAUS/EPSCAxplor/issues/11) | pr | [ ] | feat(ingestion): build download and extract pipeline stages |
+| [#11](https://github.com/BoilerHAUS/EPSCAxplor/issues/11) | pr | [x] | feat(ingestion): build download and extract pipeline stages |
 | [#12](https://github.com/BoilerHAUS/EPSCAxplor/issues/12) | pr | [x] | feat(ingestion): build classify and chunk pipeline stages |
 | [#13](https://github.com/BoilerHAUS/EPSCAxplor/issues/13) | pr | [x] | feat(ingestion): build embed, store, and pipeline orchestrator |
 | [#14](https://github.com/BoilerHAUS/EPSCAxplor/issues/14) | no-pr | [ ] | ops: run Phase 1 POC ingestion (IBEW Generation, Sheet Metal, UA) |

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -38,7 +38,7 @@ Goal: End-to-end pipeline validated against 3 unions (IBEW Generation, Sheet Met
 |---|------|--------|-------|
 | [#11](https://github.com/BoilerHAUS/EPSCAxplor/issues/11) | pr | [ ] | feat(ingestion): build download and extract pipeline stages |
 | [#12](https://github.com/BoilerHAUS/EPSCAxplor/issues/12) | pr | [x] | feat(ingestion): build classify and chunk pipeline stages |
-| [#13](https://github.com/BoilerHAUS/EPSCAxplor/issues/13) | pr | [ ] | feat(ingestion): build embed, store, and pipeline orchestrator |
+| [#13](https://github.com/BoilerHAUS/EPSCAxplor/issues/13) | pr | [x] | feat(ingestion): build embed, store, and pipeline orchestrator |
 | [#14](https://github.com/BoilerHAUS/EPSCAxplor/issues/14) | no-pr | [ ] | ops: run Phase 1 POC ingestion (IBEW Generation, Sheet Metal, UA) |
 | [#15](https://github.com/BoilerHAUS/EPSCAxplor/issues/15) | pr | [ ] | feat(rag): implement query pre-processing (nuclear detection, union/scope detection) |
 | [#16](https://github.com/BoilerHAUS/EPSCAxplor/issues/16) | pr | [ ] | feat(rag): implement Qdrant filtered similarity search and context assembly |

--- a/services/ingestion/classify.py
+++ b/services/ingestion/classify.py
@@ -31,6 +31,8 @@ class DocumentMetadata:
     agreement_scope: str | None
     effective_date: str
     expiry_date: str | None
+    title: str
+    source_url: str | None
 
 
 @dataclass
@@ -57,18 +59,19 @@ def _to_date_str(value: object) -> str:
 
 
 @functools.lru_cache(maxsize=8)
-def _load_manifest_entries(manifest_path: Path) -> list[dict[str, object]]:
+def _load_manifest_entries(manifest_path: Path) -> tuple[dict[str, object], ...]:
     """
     Load and cache manifest entries from a corpus_manifest.yaml file.
 
-    Caching avoids repeated file I/O and YAML parsing when ``classify`` is
-    called once per document in a pipeline run against a fixed manifest.
-    The cache is keyed on the absolute path, so tests using isolated
+    Returns an immutable tuple so that callers cannot accidentally mutate the
+    cached value.  Caching avoids repeated file I/O and YAML parsing when
+    ``classify`` is called once per document in a pipeline run against a fixed
+    manifest.  The cache is keyed on the absolute path, so tests using isolated
     ``tmp_path`` manifests each get their own cache entry.
     """
     with manifest_path.open() as f:
         data = yaml.safe_load(f) or {}
-    return list(data.get("documents", []))
+    return tuple(data.get("documents", []))
 
 
 def classify(
@@ -96,6 +99,7 @@ def classify(
     for entry in entries:
         if entry.get("source_filename") == filename:
             expiry_raw = entry.get("expiry_date")
+            source_url_raw = entry.get("source_url")
             return ClassifiedDocument(
                 extracted=doc,
                 metadata=DocumentMetadata(
@@ -108,6 +112,8 @@ def classify(
                     ),
                     effective_date=_to_date_str(entry["effective_date"]),
                     expiry_date=_to_date_str(expiry_raw) if expiry_raw is not None else None,
+                    title=str(entry.get("title", "")),
+                    source_url=str(source_url_raw) if source_url_raw is not None else None,
                 ),
             )
 

--- a/services/ingestion/embed.py
+++ b/services/ingestion/embed.py
@@ -1,0 +1,71 @@
+"""
+Stage 5: Embed — generate 768-dimensional embeddings for chunks via Ollama.
+
+Calls Ollama's /api/embed endpoint (batch-capable) using the nomic-embed-text
+model.  Chunks are sent in batches of BATCH_SIZE to bound per-request payload
+size.  The caller receives embeddings in the same order as the input chunks.
+
+Environment variables:
+    OLLAMA_BASE_URL: Base URL for the Ollama instance.
+                     Default: http://127.0.0.1:11434
+"""
+
+from __future__ import annotations
+
+import os
+from chunk import Chunk
+
+import httpx
+
+OLLAMA_BASE_URL: str = os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+EMBED_MODEL: str = "nomic-embed-text"
+BATCH_SIZE: int = 32
+
+
+async def embed_chunks(
+    chunks: list[Chunk],
+    *,
+    base_url: str = OLLAMA_BASE_URL,
+    batch_size: int = BATCH_SIZE,
+) -> list[list[float]]:
+    """
+    Generate embeddings for a list of chunks using Ollama's nomic-embed-text model.
+
+    Sends chunks in batches of `batch_size` to Ollama's /api/embed endpoint.
+    Each embedding is a list of 768 floats.
+
+    Args:
+        chunks:     Chunks produced by chunk_document().
+        base_url:   Ollama base URL. Defaults to OLLAMA_BASE_URL env var.
+        batch_size: Number of texts per HTTP request. Defaults to BATCH_SIZE.
+
+    Returns:
+        List of embedding vectors in the same order as `chunks`.
+
+    Raises:
+        httpx.HTTPStatusError: If Ollama returns a non-2xx response.
+        httpx.RequestError:    If the request cannot be sent (connection refused, etc.).
+    """
+    if not chunks:
+        return []
+
+    texts = [c.text for c in chunks]
+    embeddings: list[list[float]] = []
+
+    async with httpx.AsyncClient(base_url=base_url, timeout=120.0) as client:
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i : i + batch_size]
+            response = await client.post(
+                "/api/embed",
+                json={"model": EMBED_MODEL, "input": batch},
+            )
+            response.raise_for_status()
+            data = response.json()
+            if "embeddings" not in data:
+                raise ValueError(
+                    f"Ollama response missing 'embeddings' key; "
+                    f"got: {list(data.keys())}"
+                )
+            embeddings.extend(data["embeddings"])
+
+    return embeddings

--- a/services/ingestion/run_pipeline.py
+++ b/services/ingestion/run_pipeline.py
@@ -1,13 +1,13 @@
 """
 Ingestion pipeline orchestrator.
 
-Runs pipeline stages in order. Use --stage to run a single stage or
-omit it to run all stages sequentially.
+Runs all six stages sequentially against every document in the corpus manifest,
+or a single stage when --stage is specified.
 
 Usage:
-    python run_pipeline.py --stage download
-    python run_pipeline.py --stage extract
-    python run_pipeline.py           # runs all stages
+    python run_pipeline.py                   # runs all stages for all documents
+    python run_pipeline.py --dry-run         # skips store (embed → /dev/null)
+    python run_pipeline.py --stage download  # runs only the download stage
 """
 
 from __future__ import annotations
@@ -15,36 +15,141 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import time
+from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger("run_pipeline")
 
 STAGES = ["download", "extract", "classify", "chunk", "embed", "store"]
 
+_HERE = Path(__file__).parent
+
+
+# ─── Single-stage helpers ─────────────────────────────────────────────────────
+
+
+async def _run_download() -> None:
+    from download import run_download
+
+    results = await run_download()
+    for r in results:
+        detail = r.file_hash or r.error or ""
+        logger.info("[%s] %s — %s", r.status.value.upper(), r.source_filename, detail)
+
+
+# ─── Full pipeline (per-document) ─────────────────────────────────────────────
+
+
+async def _run_full_pipeline(dry_run: bool) -> None:
+    """
+    Run all six stages end-to-end for every document found in the corpus.
+
+    Download stage is skipped here (run it separately via --stage download).
+    Stages 2–6 operate on every PDF already present in corpus/.
+    """
+    from chunk import chunk_document
+
+    import yaml
+
+    from classify import classify
+    from download import CORPUS_DIR, CORPUS_MANIFEST, resolve_corpus_path
+    from embed import embed_chunks
+    from extract import extract_pdf
+    from store import store_document
+
+    with CORPUS_MANIFEST.open() as f:
+        manifest_data = yaml.safe_load(f) or {}
+    entries = list(manifest_data.get("documents", []))
+
+    doc_count = 0
+    total_chunks = 0
+    t_start = time.monotonic()
+
+    for entry in entries:
+        pdf_path = resolve_corpus_path(entry, CORPUS_DIR)
+
+        if not pdf_path.exists():
+            logger.warning("PDF not found, skipping: %s", pdf_path)
+            continue
+
+        source_filename = entry.get("source_filename", pdf_path.name)
+        logger.info("--- %s ---", source_filename)
+        t_doc = time.monotonic()
+
+        # Stage 2: Extract
+        extracted = extract_pdf(pdf_path)
+        logger.info("  extract: %d blocks, %d pages", len(extracted.blocks), extracted.page_count)
+
+        # Stage 3: Classify
+        classified = classify(extracted)
+        logger.info(
+            "  classify: %s / %s",
+            classified.metadata.union_name,
+            classified.metadata.document_type,
+        )
+
+        # Stage 4: Chunk
+        chunks = chunk_document(classified)
+        logger.info("  chunk: %d chunks", len(chunks))
+        total_chunks += len(chunks)
+
+        # Stage 5: Embed
+        embeddings = await embed_chunks(chunks)
+        logger.info("  embed: %d vectors", len(embeddings))
+
+        # Stage 6: Store (skipped on --dry-run)
+        if dry_run:
+            logger.info("  store: SKIPPED (--dry-run)")
+        else:
+            await store_document(classified, chunks, embeddings)
+            logger.info("  store: OK")
+
+        elapsed = time.monotonic() - t_doc
+        logger.info("  done in %.1fs", elapsed)
+        doc_count += 1
+
+    total_elapsed = time.monotonic() - t_start
+    logger.info(
+        "Pipeline complete: %d documents, %d chunks, %.1fs total",
+        doc_count,
+        total_chunks,
+        total_elapsed,
+    )
+
+
+# ─── Entry point ──────────────────────────────────────────────────────────────
+
 
 async def run_stage(stage: str) -> None:
     if stage == "download":
-        from download import run_download
-
-        results = await run_download()
-        for r in results:
-            detail = r.file_hash or r.error or ""
-            logger.info("[%s] %s — %s", r.status.value.upper(), r.source_filename, detail)
-    elif stage == "extract":
-        logger.info("Extract stage not yet wired to orchestrator — run extract.py directly")
-    elif stage == "classify":
-        logger.info("Classify stage not yet wired to orchestrator — use classify.py directly")
-    elif stage == "chunk":
-        logger.info("Chunk stage not yet wired to orchestrator — use chunk.py directly")
+        await _run_download()
+    elif stage in ("extract", "classify", "chunk", "embed", "store"):
+        logger.error(
+            "Stage '%s' cannot be run in isolation — "
+            "omit --stage to run the full pipeline, or use --stage download",
+            stage,
+        )
+        raise SystemExit(1)
     else:
-        logger.warning("Stage '%s' not yet implemented", stage)
+        logger.warning("Unknown stage '%s'", stage)
 
 
-async def main(stages: list[str]) -> None:
-    for stage in stages:
-        logger.info("=== Stage: %s ===", stage)
-        await run_stage(stage)
-    logger.info("Pipeline complete.")
+async def main(stages: list[str], dry_run: bool) -> None:
+    if stages == STAGES:
+        # Full pipeline run
+        t0 = time.monotonic()
+        logger.info("=== Download ===")
+        await _run_download()
+        logger.info("=== Pipeline (extract → store) ===")
+        await _run_full_pipeline(dry_run=dry_run)
+        logger.info("Total wall time: %.1fs", time.monotonic() - t0)
+    else:
+        # Single-stage run
+        for stage in stages:
+            logger.info("=== Stage: %s ===", stage)
+            await run_stage(stage)
+        logger.info("Done.")
 
 
 if __name__ == "__main__":
@@ -55,6 +160,12 @@ if __name__ == "__main__":
         default=None,
         help="Run a single stage (default: run all stages)",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Skip the store stage (embed is still computed but not persisted)",
+    )
     args = parser.parse_args()
     selected = [args.stage] if args.stage else STAGES
-    asyncio.run(main(selected))
+    asyncio.run(main(selected, dry_run=args.dry_run))

--- a/services/ingestion/store.py
+++ b/services/ingestion/store.py
@@ -1,0 +1,230 @@
+"""
+Stage 6: Store — upsert embeddings to Qdrant and register documents in PostgreSQL.
+
+For each ingested document:
+1. Compute SHA-256 of the source PDF for change detection.
+2. Upsert a row in the PostgreSQL `documents` table (idempotent — updates
+   file_hash, chunk_count, and ingested_at on re-run).
+3. Build Qdrant PointStructs with full metadata payload and upsert to the
+   `epsca_chunks` collection.
+
+Point IDs are deterministic: uuid5(NAMESPACE_URL, "{document_id}:{chunk_index}"),
+so re-running the pipeline on the same document overwrites existing points rather
+than creating duplicates.
+
+Environment variables:
+    QDRANT_URL:    Base URL for the Qdrant instance.  Default: http://127.0.0.1:6333
+    POSTGRES_DSN:  asyncpg-compatible connection string.
+                   Default: postgresql://epsca_user:password@localhost/epsca
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import uuid
+from chunk import Chunk
+from pathlib import Path
+
+import asyncpg
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.models import PointStruct
+
+from classify import ClassifiedDocument
+
+logger = logging.getLogger(__name__)
+
+QDRANT_URL: str = os.getenv("QDRANT_URL", "http://127.0.0.1:6333")
+QDRANT_COLLECTION: str = "epsca_chunks"
+# No default — must be provided via environment or the postgres_dsn kwarg.
+# Fail fast rather than silently connecting to the wrong host.
+POSTGRES_DSN: str = os.getenv("POSTGRES_DSN", "")
+
+
+# ─── Internal helpers ─────────────────────────────────────────────────────────
+
+
+def _compute_sha256(path: Path) -> str:
+    """Return the SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for block in iter(lambda: f.read(65536), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _make_point_id(document_id: uuid.UUID, chunk_index: int) -> str:
+    """Return a deterministic UUID string for a Qdrant point."""
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"{document_id}:{chunk_index}"))
+
+
+async def _upsert_document_row(
+    conn: asyncpg.Connection,
+    doc: ClassifiedDocument,
+    file_hash: str,
+    chunk_count: int,
+) -> uuid.UUID:
+    """
+    Insert or update the document row in PostgreSQL.
+
+    Uses SELECT FOR UPDATE inside a serialised transaction to prevent duplicate
+    inserts from concurrent pipeline runs on the same document.
+
+    Returns the document's UUID.
+    """
+    source_filename = doc.extracted.source_path.name
+
+    async with conn.transaction():
+        existing = await conn.fetchrow(
+            "SELECT id FROM documents WHERE source_filename = $1 FOR UPDATE",
+            source_filename,
+        )
+
+        if existing:
+            row = await conn.fetchrow(
+                """
+                UPDATE documents
+                   SET file_hash    = $1,
+                       chunk_count  = $2,
+                       ingested_at  = NOW(),
+                       updated_at   = NOW()
+                 WHERE id = $3
+                 RETURNING id
+                """,
+                file_hash,
+                chunk_count,
+                existing["id"],
+            )
+        else:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO documents (
+                    union_name, document_type, agreement_scope,
+                    title, source_url, source_filename,
+                    effective_date, expiry_date,
+                    file_hash, chunk_count, ingested_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+                RETURNING id
+                """,
+                doc.metadata.union_name,
+                doc.metadata.document_type,
+                doc.metadata.agreement_scope,
+                doc.metadata.title,
+                doc.metadata.source_url,
+                source_filename,
+                doc.metadata.effective_date,
+                doc.metadata.expiry_date,
+                file_hash,
+                chunk_count,
+            )
+
+    if row is None:
+        raise RuntimeError(
+            f"Expected RETURNING id after upsert for '{source_filename}', got nothing"
+        )
+    return row["id"]
+
+
+def _build_points(
+    document_id: uuid.UUID,
+    doc: ClassifiedDocument,
+    chunks: list[Chunk],
+    embeddings: list[list[float]],
+) -> list[PointStruct]:
+    """Build Qdrant PointStructs with full metadata payload."""
+    source_filename = doc.extracted.source_path.name
+    return [
+        PointStruct(
+            id=_make_point_id(document_id, chunk.chunk_index),
+            vector=embeddings[i],
+            payload={
+                "document_id": str(document_id),
+                "source_filename": source_filename,
+                "union_name": doc.metadata.union_name,
+                "document_type": doc.metadata.document_type,
+                "agreement_scope": doc.metadata.agreement_scope,
+                "effective_date": doc.metadata.effective_date,
+                "expiry_date": doc.metadata.expiry_date,
+                "chunk_index": chunk.chunk_index,
+                "article_number": chunk.article_number,
+                "article_title": chunk.article_title,
+                "section_number": chunk.section_number,
+                "page_number": chunk.page_number,
+                "is_table": chunk.is_table,
+                "text": chunk.text,
+            },
+        )
+        for i, chunk in enumerate(chunks)
+    ]
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+
+async def store_document(
+    doc: ClassifiedDocument,
+    chunks: list[Chunk],
+    embeddings: list[list[float]],
+    *,
+    qdrant_url: str = QDRANT_URL,
+    postgres_dsn: str = POSTGRES_DSN,
+) -> None:
+    """
+    Persist a document's chunks and embeddings.
+
+    Upserts a row into the PostgreSQL `documents` table, then upserts all
+    chunk embeddings into the Qdrant `epsca_chunks` collection.  Safe to
+    re-run — duplicate document rows are updated in place, and Qdrant points
+    use deterministic IDs so they are overwritten rather than duplicated.
+
+    Args:
+        doc:          ClassifiedDocument produced by classify.py.
+        chunks:       Chunks produced by chunk_document().
+        embeddings:   Embedding vectors from embed_chunks(), same order as chunks.
+        qdrant_url:   Qdrant base URL (overridable for testing).
+        postgres_dsn: asyncpg-compatible DSN (overridable for testing).
+
+    Raises:
+        ValueError: If len(chunks) != len(embeddings).
+    """
+    if len(chunks) != len(embeddings):
+        raise ValueError(
+            f"chunks ({len(chunks)}) and embeddings ({len(embeddings)}) must have "
+            "the same length"
+        )
+
+    if not postgres_dsn:
+        raise RuntimeError(
+            "POSTGRES_DSN environment variable is required; "
+            "set it to your asyncpg connection string."
+        )
+
+    file_hash = _compute_sha256(doc.extracted.source_path)
+
+    async with asyncpg.create_pool(postgres_dsn) as pool:
+        async with pool.acquire() as conn:
+            document_id = await _upsert_document_row(conn, doc, file_hash, len(chunks))
+
+    logger.info(
+        "Registered document %s (id=%s, chunks=%d)",
+        doc.extracted.source_path.name,
+        document_id,
+        len(chunks),
+    )
+
+    if not chunks:
+        return
+
+    points = _build_points(document_id, doc, chunks, embeddings)
+    qdrant = AsyncQdrantClient(url=qdrant_url)
+    try:
+        await qdrant.upsert(collection_name=QDRANT_COLLECTION, points=points)
+        logger.info(
+            "Upserted %d points to Qdrant collection '%s'",
+            len(points),
+            QDRANT_COLLECTION,
+        )
+    finally:
+        await qdrant.close()

--- a/services/ingestion/tests/test_chunk.py
+++ b/services/ingestion/tests/test_chunk.py
@@ -17,6 +17,8 @@ def _make_metadata() -> DocumentMetadata:
         agreement_scope="generation",
         effective_date="2025-05-01",
         expiry_date="2030-04-30",
+        title="IBEW Test Agreement",
+        source_url="PLACEHOLDER",
     )
 
 

--- a/services/ingestion/tests/test_classify.py
+++ b/services/ingestion/tests/test_classify.py
@@ -21,6 +21,8 @@ def _manifest_entry(
     agreement_scope: str | None = "generation",
     effective_date: str = "2025-05-01",
     expiry_date: str | None = "2030-04-30",
+    title: str = "IBEW Test Agreement",
+    source_url: str | None = "PLACEHOLDER",
 ) -> dict:
     return {
         "union_name": union_name,
@@ -29,6 +31,8 @@ def _manifest_entry(
         "source_filename": source_filename,
         "effective_date": effective_date,
         "expiry_date": expiry_date,
+        "title": title,
+        "source_url": source_url,
     }
 
 
@@ -141,6 +145,32 @@ class TestMetadataFields:
         result = classify(doc, manifest_path)
         assert result.metadata.expiry_date is None
 
+    def test_title_assigned(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path,
+            [_manifest_entry("ibew.pdf", title="IBEW Generation 2025-2030 Collective Agreement")],
+        )
+        doc = _make_extracted("ibew.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.title == "IBEW Generation 2025-2030 Collective Agreement"
+
+    def test_source_url_assigned(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(
+            tmp_path,
+            [_manifest_entry("ibew.pdf", source_url="https://example.com/doc.pdf")],
+        )
+        doc = _make_extracted("ibew.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.source_url == "https://example.com/doc.pdf"
+
+    def test_source_url_none_when_absent_from_manifest(self, tmp_path: Path) -> None:
+        entry = _manifest_entry("ibew.pdf")
+        del entry["source_url"]
+        manifest_path = _write_manifest(tmp_path, [entry])
+        doc = _make_extracted("ibew.pdf", tmp_path)
+        result = classify(doc, manifest_path)
+        assert result.metadata.source_url is None
+
 
 class TestFilenameMatching:
     def test_matches_by_source_filename(self, tmp_path: Path) -> None:
@@ -200,6 +230,8 @@ class TestYamlDateNormalisation:
             "  - union_name: IBEW\n"
             "    document_type: primary_ca\n"
             "    agreement_scope: generation\n"
+            "    title: IBEW Test\n"
+            "    source_url: PLACEHOLDER\n"
             "    source_filename: date-test.pdf\n"
             "    effective_date: 2025-05-01\n"  # bare date → datetime.date
             "    expiry_date: 2030-04-30\n"      # bare date → datetime.date
@@ -216,6 +248,8 @@ class TestYamlDateNormalisation:
             "  - union_name: Sheet Metal\n"
             "    document_type: primary_ca\n"
             "    agreement_scope: null\n"
+            "    title: Sheet Metal Test\n"
+            "    source_url: PLACEHOLDER\n"
             "    source_filename: sm-date.pdf\n"
             "    effective_date: 2025-05-01\n"
             "    expiry_date: 2030-04-30\n"

--- a/services/ingestion/tests/test_embed.py
+++ b/services/ingestion/tests/test_embed.py
@@ -1,0 +1,208 @@
+"""Tests for embed.py — Stage 5 of the ingestion pipeline."""
+
+from __future__ import annotations
+
+import math
+from chunk import Chunk
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from embed import EMBED_MODEL, embed_chunks
+
+EMBED_DIM = 768
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_chunk(text: str, index: int = 0) -> Chunk:
+    return Chunk(
+        text=text,
+        page_number=1,
+        is_table=False,
+        article_number="Article 1",
+        section_number=None,
+        article_title="Scope",
+        chunk_index=index,
+    )
+
+
+def _fake_embedding() -> list[float]:
+    return [0.1] * EMBED_DIM
+
+
+def _mock_client(batches: list[list[list[float]]]) -> MagicMock:
+    """
+    Return a mock AsyncClient context manager whose .post() yields one response
+    per call, each containing the embedding batch provided.
+    """
+    responses = []
+    for batch_embeddings in batches:
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"embeddings": batch_embeddings}
+        responses.append(resp)
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(side_effect=responses)
+    return mock_client
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestEmbedEmpty:
+    @pytest.mark.asyncio
+    async def test_empty_chunks_returns_empty_list(self) -> None:
+        result = await embed_chunks([])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_empty_chunks_makes_no_http_calls(self) -> None:
+        mock_client = _mock_client([])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            await embed_chunks([])
+        mock_client.post.assert_not_called()
+
+
+class TestEmbedSingleBatch:
+    @pytest.mark.asyncio
+    async def test_single_chunk_returns_one_embedding(self) -> None:
+        chunks = [_make_chunk("hello world")]
+        mock_client = _mock_client([[_fake_embedding()]])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            result = await embed_chunks(chunks)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_embedding_has_correct_dimension(self) -> None:
+        chunks = [_make_chunk("hello world")]
+        mock_client = _mock_client([[_fake_embedding()]])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            result = await embed_chunks(chunks)
+        assert len(result[0]) == EMBED_DIM
+
+    @pytest.mark.asyncio
+    async def test_three_chunks_single_batch_makes_one_call(self) -> None:
+        chunks = [_make_chunk(f"text {i}", i) for i in range(3)]
+        mock_client = _mock_client([[_fake_embedding()] * 3])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            result = await embed_chunks(chunks, batch_size=32)
+        assert mock_client.post.call_count == 1
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_correct_model_sent_in_request(self) -> None:
+        chunks = [_make_chunk("hello")]
+        mock_client = _mock_client([[_fake_embedding()]])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            await embed_chunks(chunks)
+        call_kwargs = mock_client.post.call_args
+        payload = call_kwargs.kwargs["json"]
+        assert payload["model"] == EMBED_MODEL
+
+    @pytest.mark.asyncio
+    async def test_chunk_texts_sent_as_input(self) -> None:
+        chunks = [_make_chunk("first text"), _make_chunk("second text", 1)]
+        mock_client = _mock_client([[_fake_embedding(), _fake_embedding()]])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            await embed_chunks(chunks)
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["input"] == ["first text", "second text"]
+
+
+class TestEmbedBatching:
+    @pytest.mark.asyncio
+    async def test_exact_batch_size_makes_one_call(self) -> None:
+        n = 4
+        chunks = [_make_chunk(f"t{i}", i) for i in range(n)]
+        mock_client = _mock_client([[_fake_embedding()] * n])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            result = await embed_chunks(chunks, batch_size=4)
+        assert mock_client.post.call_count == 1
+        assert len(result) == n
+
+    @pytest.mark.asyncio
+    async def test_one_over_batch_size_makes_two_calls(self) -> None:
+        n = 5
+        chunks = [_make_chunk(f"t{i}", i) for i in range(n)]
+        mock_client = _mock_client([
+            [_fake_embedding()] * 4,
+            [_fake_embedding()],
+        ])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            result = await embed_chunks(chunks, batch_size=4)
+        assert mock_client.post.call_count == 2
+        assert len(result) == n
+
+    @pytest.mark.asyncio
+    async def test_batch_count_matches_ceil_division(self) -> None:
+        n = 70
+        batch_size = 32
+        expected_calls = math.ceil(n / batch_size)
+        chunks = [_make_chunk(f"t{i}", i) for i in range(n)]
+        # Build response batches: first two full, last partial
+        batches = []
+        for start in range(0, n, batch_size):
+            size = min(batch_size, n - start)
+            batches.append([_fake_embedding()] * size)
+        mock_client = _mock_client(batches)
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            result = await embed_chunks(chunks, batch_size=batch_size)
+        assert mock_client.post.call_count == expected_calls
+        assert len(result) == n
+
+    @pytest.mark.asyncio
+    async def test_embeddings_returned_in_chunk_order(self) -> None:
+        """Embeddings must come back in the same order as input chunks."""
+        n = 5
+        chunks = [_make_chunk(f"t{i}", i) for i in range(n)]
+        # Use distinct marker values to verify ordering
+        ordered_embeddings = [[float(i)] * EMBED_DIM for i in range(n)]
+        mock_client = _mock_client([
+            ordered_embeddings[:4],
+            ordered_embeddings[4:],
+        ])
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            result = await embed_chunks(chunks, batch_size=4)
+        for i, vec in enumerate(result):
+            assert vec[0] == float(i), f"Chunk {i} embedding out of order"
+
+
+class TestEmbedErrorPropagation:
+    @pytest.mark.asyncio
+    async def test_http_error_propagates(self) -> None:
+        import httpx
+
+        chunks = [_make_chunk("hello")]
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "500",
+                request=MagicMock(),
+                response=MagicMock(status_code=500),
+            )
+        )
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(httpx.HTTPStatusError):
+                await embed_chunks(chunks)
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_raises_value_error(self) -> None:
+        """Ollama returning 200 with {'error': '...'} must raise ValueError, not KeyError."""
+        chunks = [_make_chunk("hello")]
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"error": "model not found"}
+        mock_client.post = AsyncMock(return_value=resp)
+        with patch("embed.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(ValueError, match="embeddings"):
+                await embed_chunks(chunks)

--- a/services/ingestion/tests/test_store.py
+++ b/services/ingestion/tests/test_store.py
@@ -1,0 +1,450 @@
+"""Tests for store.py — Stage 6 of the ingestion pipeline."""
+
+from __future__ import annotations
+
+import uuid
+from chunk import Chunk
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from classify import ClassifiedDocument, DocumentMetadata
+from extract import ExtractedDocument
+from store import (
+    QDRANT_COLLECTION,
+    _make_point_id,
+    store_document,
+)
+
+EMBED_DIM = 768
+_TEST_DSN = "postgresql://test/test"
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_metadata(
+    union_name: str = "IBEW",
+    document_type: str = "primary_ca",
+    agreement_scope: str | None = "generation",
+    effective_date: str = "2025-05-01",
+    expiry_date: str | None = "2030-04-30",
+    title: str = "IBEW Generation 2025-2030 Collective Agreement",
+    source_url: str | None = "PLACEHOLDER",
+) -> DocumentMetadata:
+    return DocumentMetadata(
+        union_name=union_name,
+        document_type=document_type,
+        agreement_scope=agreement_scope,
+        effective_date=effective_date,
+        expiry_date=expiry_date,
+        title=title,
+        source_url=source_url,
+    )
+
+
+def _make_doc(tmp_path: Path, filename: str = "ibew.pdf") -> ClassifiedDocument:
+    pdf = tmp_path / filename
+    pdf.write_bytes(b"%PDF-1.4 fake content for hashing")
+    extracted = ExtractedDocument(source_path=pdf, blocks=[], page_count=1)
+    return ClassifiedDocument(extracted=extracted, metadata=_make_metadata())
+
+
+def _make_chunk(index: int = 0) -> Chunk:
+    return Chunk(
+        text=f"chunk text {index}",
+        page_number=1,
+        is_table=False,
+        article_number="Article 1",
+        section_number="1.01",
+        article_title="Scope",
+        chunk_index=index,
+    )
+
+
+def _fake_embedding() -> list[float]:
+    return [0.1] * EMBED_DIM
+
+
+def _make_pg_conn(
+    document_id: uuid.UUID | None = None,
+    *,
+    existing: bool = True,
+    row_after_upsert: dict | None = None,
+) -> AsyncMock:
+    """
+    Build a mock asyncpg connection with a working transaction() context manager.
+
+    When `existing=True` (default) the first fetchrow (SELECT FOR UPDATE) returns
+    a row, triggering the UPDATE path.  When `existing=False` the SELECT returns
+    None, triggering the INSERT path.
+
+    `row_after_upsert` overrides the second fetchrow return value (UPDATE/INSERT
+    RETURNING id).  Pass None explicitly to test the row=None error path.
+    """
+    doc_id = document_id or uuid.uuid4()
+    returning_row = row_after_upsert if row_after_upsert is not None else {"id": doc_id}
+
+    conn = AsyncMock()
+
+    if existing:
+        conn.fetchrow = AsyncMock(side_effect=[{"id": doc_id}, returning_row])
+    else:
+        conn.fetchrow = AsyncMock(side_effect=[None, returning_row])
+
+    # asyncpg conn.transaction() is a sync call returning an async context manager
+    tx_ctx = AsyncMock()
+    tx_ctx.__aenter__ = AsyncMock(return_value=tx_ctx)
+    tx_ctx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx_ctx)
+
+    return conn
+
+
+def _make_pg_pool(conn: AsyncMock) -> MagicMock:
+    """Build a mock asyncpg pool context manager."""
+    pool = MagicMock()
+    pool.__aenter__ = AsyncMock(return_value=pool)
+    pool.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+    return pool
+
+
+def _make_qdrant_client() -> AsyncMock:
+    client = AsyncMock()
+    client.upsert = AsyncMock(return_value=None)
+    client.close = AsyncMock(return_value=None)
+    return client
+
+
+# ─── Unit tests: _make_point_id ───────────────────────────────────────────────
+
+
+class TestMakePointId:
+    def test_returns_string(self) -> None:
+        doc_id = uuid.uuid4()
+        result = _make_point_id(doc_id, 0)
+        assert isinstance(result, str)
+
+    def test_valid_uuid_format(self) -> None:
+        doc_id = uuid.uuid4()
+        result = _make_point_id(doc_id, 0)
+        parsed = uuid.UUID(result)
+        assert str(parsed) == result
+
+    def test_different_chunk_index_produces_different_id(self) -> None:
+        doc_id = uuid.uuid4()
+        id_0 = _make_point_id(doc_id, 0)
+        id_1 = _make_point_id(doc_id, 1)
+        assert id_0 != id_1
+
+    def test_different_document_id_produces_different_id(self) -> None:
+        doc_id_a = uuid.uuid4()
+        doc_id_b = uuid.uuid4()
+        id_a = _make_point_id(doc_id_a, 0)
+        id_b = _make_point_id(doc_id_b, 0)
+        assert id_a != id_b
+
+    def test_deterministic_for_same_inputs(self) -> None:
+        doc_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        id_1 = _make_point_id(doc_id, 5)
+        id_2 = _make_point_id(doc_id, 5)
+        assert id_1 == id_2
+
+
+# ─── Integration tests: store_document ───────────────────────────────────────
+
+
+class TestStoreDocumentPostgres:
+    @pytest.mark.asyncio
+    async def test_postgres_upsert_called(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=_make_qdrant_client()),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        # fetchrow is called at least once (SELECT FOR UPDATE + UPDATE or INSERT)
+        assert conn.fetchrow.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_postgres_wrapped_in_transaction(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=_make_qdrant_client()),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        conn.transaction.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_postgres_receives_correct_union_name(self, tmp_path: Path) -> None:
+        """INSERT path carries union_name — use existing=False to trigger it."""
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn(existing=False)
+        pool = _make_pg_pool(conn)
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=_make_qdrant_client()),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        # All fetchrow args across SELECT + INSERT calls
+        all_args = [arg for c in conn.fetchrow.call_args_list for arg in c.args]
+        assert "IBEW" in all_args
+
+    @pytest.mark.asyncio
+    async def test_postgres_receives_chunk_count(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        n = 3
+        chunks = [_make_chunk(i) for i in range(n)]
+        embeddings = [_fake_embedding() for _ in range(n)]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=_make_qdrant_client()),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        all_args = [arg for c in conn.fetchrow.call_args_list for arg in c.args]
+        assert n in all_args
+
+    @pytest.mark.asyncio
+    async def test_postgres_receives_source_filename(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path, "ibew.pdf")
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=_make_qdrant_client()),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        all_args = [arg for c in conn.fetchrow.call_args_list for arg in c.args]
+        assert "ibew.pdf" in all_args
+
+    @pytest.mark.asyncio
+    async def test_row_none_after_upsert_raises_runtime_error(
+        self, tmp_path: Path
+    ) -> None:
+        """If UPDATE/INSERT RETURNING yields no row, raise RuntimeError immediately."""
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        # existing=True, but the UPDATE RETURNING returns None (e.g. row deleted mid-tx)
+        conn = _make_pg_conn(existing=True, row_after_upsert=None)
+        # Override fetchrow: SELECT returns a row, UPDATE RETURNING yields None
+        conn.fetchrow = AsyncMock(side_effect=[{"id": uuid.uuid4()}, None])
+        tx_ctx = AsyncMock()
+        tx_ctx.__aenter__ = AsyncMock(return_value=tx_ctx)
+        tx_ctx.__aexit__ = AsyncMock(return_value=False)
+        conn.transaction = MagicMock(return_value=tx_ctx)
+        pool = _make_pg_pool(conn)
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=_make_qdrant_client()),
+        ):
+            with pytest.raises(RuntimeError, match="Expected RETURNING id"):
+                await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+
+class TestStoreDocumentQdrant:
+    @pytest.mark.asyncio
+    async def test_qdrant_upsert_called_once(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+        qdrant = _make_qdrant_client()
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=qdrant),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        qdrant.upsert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_qdrant_upserts_to_correct_collection(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+        qdrant = _make_qdrant_client()
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=qdrant),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        call_kwargs = qdrant.upsert.call_args.kwargs
+        assert call_kwargs["collection_name"] == QDRANT_COLLECTION
+
+    @pytest.mark.asyncio
+    async def test_qdrant_point_count_matches_chunks(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        n = 5
+        chunks = [_make_chunk(i) for i in range(n)]
+        embeddings = [_fake_embedding() for _ in range(n)]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+        qdrant = _make_qdrant_client()
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=qdrant),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        call_kwargs = qdrant.upsert.call_args.kwargs
+        assert len(call_kwargs["points"]) == n
+
+    @pytest.mark.asyncio
+    async def test_qdrant_point_payload_has_union_name(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+        qdrant = _make_qdrant_client()
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=qdrant),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        points = qdrant.upsert.call_args.kwargs["points"]
+        assert points[0].payload["union_name"] == "IBEW"
+
+    @pytest.mark.asyncio
+    async def test_qdrant_point_payload_has_text(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+        qdrant = _make_qdrant_client()
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=qdrant),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        points = qdrant.upsert.call_args.kwargs["points"]
+        assert points[0].payload["text"] == "chunk text 0"
+
+    @pytest.mark.asyncio
+    async def test_qdrant_point_ids_are_deterministic(self, tmp_path: Path) -> None:
+        """Re-running store_document produces the same point IDs (idempotent upsert)."""
+        fixed_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+
+        conn1 = _make_pg_conn(fixed_id)
+        pool1 = _make_pg_pool(conn1)
+        qdrant1 = _make_qdrant_client()
+
+        conn2 = _make_pg_conn(fixed_id)
+        pool2 = _make_pg_pool(conn2)
+        qdrant2 = _make_qdrant_client()
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool1),
+            patch("store.AsyncQdrantClient", return_value=qdrant1),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool2),
+            patch("store.AsyncQdrantClient", return_value=qdrant2),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        id_run1 = qdrant1.upsert.call_args.kwargs["points"][0].id
+        id_run2 = qdrant2.upsert.call_args.kwargs["points"][0].id
+        assert id_run1 == id_run2
+
+    @pytest.mark.asyncio
+    async def test_qdrant_close_called_after_upsert(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+        qdrant = _make_qdrant_client()
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=qdrant),
+        ):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+        qdrant.close.assert_called_once()
+
+
+class TestStoreDocumentValidation:
+    @pytest.mark.asyncio
+    async def test_mismatched_chunks_and_embeddings_raises(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0), _make_chunk(1)]
+        embeddings = [_fake_embedding()]  # too few
+
+        with pytest.raises(ValueError, match="chunks"):
+            await store_document(doc, chunks, embeddings, postgres_dsn=_TEST_DSN)
+
+    @pytest.mark.asyncio
+    async def test_missing_postgres_dsn_raises_runtime_error(
+        self, tmp_path: Path
+    ) -> None:
+        doc = _make_doc(tmp_path)
+        chunks = [_make_chunk(0)]
+        embeddings = [_fake_embedding()]
+
+        with pytest.raises(RuntimeError, match="POSTGRES_DSN"):
+            await store_document(doc, chunks, embeddings, postgres_dsn="")
+
+    @pytest.mark.asyncio
+    async def test_empty_chunks_skips_qdrant(self, tmp_path: Path) -> None:
+        doc = _make_doc(tmp_path)
+        conn = _make_pg_conn()
+        pool = _make_pg_pool(conn)
+        qdrant = _make_qdrant_client()
+
+        with (
+            patch("store.asyncpg.create_pool", return_value=pool),
+            patch("store.AsyncQdrantClient", return_value=qdrant),
+        ):
+            await store_document(doc, [], [], postgres_dsn=_TEST_DSN)
+
+        qdrant.upsert.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #13. Completes the six-stage ingestion pipeline.

- **embed.py (Stage 5)** — async Ollama `/api/embed` via httpx, batched at 32 chunks per request, `nomic-embed-text` model (768 dims). Validates the `embeddings` key in the response body (guards against malformed HTTP 200s from Ollama).
- **store.py (Stage 6)** — asyncpg upsert to `documents` table inside a `SELECT FOR UPDATE` transaction (prevents duplicate rows from concurrent runs); deterministic Qdrant point IDs via `uuid5`; full metadata payload; `POSTGRES_DSN` env var required with fail-fast check (no hardcoded credential).
- **run_pipeline.py** — full six-stage orchestrator, `--dry-run` flag, per-doc and total timing, exits 1 for invalid `--stage` values.
- **classify.py** — `DocumentMetadata` gains `title` and `source_url` fields needed by the `documents` table; `_load_manifest_entries` now returns an immutable `tuple` from `lru_cache`.

All five issues flagged by `python-reviewer` (CRITICAL + 4 HIGH) were fixed before this commit.

## Test plan

- [ ] `python3 -m pytest tests/ -q` — 135 tests, all green
- [ ] `python3 -m ruff check .` — no errors
- [ ] Deploy to VPS; set `OLLAMA_BASE_URL`, `QDRANT_URL`, `POSTGRES_DSN` env vars in Dokploy
- [ ] Drop PDFs into `corpus/` and run `python run_pipeline.py --dry-run` — verify doc count, chunk count, and timing in logs
- [ ] Run `python run_pipeline.py` (no `--dry-run`) — verify rows appear in `documents` table and points land in `epsca_chunks` Qdrant collection