### PR TITLE
feat(rag): implement query pre-processing (#15)

### DIFF
--- a/services/api/src/rag/preprocess.py
+++ b/services/api/src/rag/preprocess.py
@@ -1,0 +1,127 @@
+"""Query pre-processing for the EPSCAxplor RAG pipeline.
+
+Performs lightweight query analysis before embedding and retrieval:
+- Nuclear context detection (widens retrieval to include NPAs)
+- Union name detection (restricts retrieval to a single union)
+- Scope detection for IBEW/Labourers (generation vs. transmission)
+- Cross-union complexity classification (routes to Sonnet vs. Haiku)
+"""
+
+import re
+
+from pydantic import BaseModel
+
+NUCLEAR_KEYWORDS: list[str] = [
+    "nuclear",
+    "OPG",
+    "Ontario Power Generation",
+    "Bruce Power",
+    "Darlington",
+    "Pickering",
+    "nuclear project",
+    "NPA",
+]
+
+# Compiled, word-boundary-aware patterns for each nuclear keyword.
+# Multi-word phrases use implicit phrase boundaries; single tokens use \b.
+_NUCLEAR_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\bnuclear\b", re.IGNORECASE),
+    re.compile(r"\bOPG\b", re.IGNORECASE),
+    re.compile(r"Ontario Power Generation", re.IGNORECASE),
+    re.compile(r"Bruce Power", re.IGNORECASE),
+    re.compile(r"\bDarlington\b", re.IGNORECASE),
+    re.compile(r"\bPickering\b", re.IGNORECASE),
+    re.compile(r"\bnuclear\s+project\b", re.IGNORECASE),
+    re.compile(r"\bNPA\b", re.IGNORECASE),
+]
+
+_SCOPE_PATTERNS: dict[str, re.Pattern[str]] = {
+    "generation": re.compile(r"\bgeneration\b", re.IGNORECASE),
+    "transmission": re.compile(r"\btransmission\b", re.IGNORECASE),
+}
+
+_CROSS_UNION_PHRASES: list[str] = [
+    "compare",
+    "difference between",
+    "all unions",
+    "across trades",
+]
+
+
+class QueryContext(BaseModel):
+    """Structured output of query pre-processing."""
+
+    union_filter: str | None
+    include_nuclear_pa: bool
+    agreement_scope: str | None
+    is_cross_union: bool
+
+
+def detect_nuclear(query: str) -> bool:
+    """Return True if the query contains any nuclear-related keyword.
+
+    Matching uses word-boundary-aware regex (case-insensitive) to avoid
+    false positives from substrings (e.g. "non-nuclear" still matches
+    "nuclear", but "npa" embedded in another word does not match "NPA").
+    """
+    return any(p.search(query) is not None for p in _NUCLEAR_PATTERNS)
+
+
+def detect_union(query: str, known_unions: list[str]) -> str | None:
+    """Return the verbatim name of the first union found in the query.
+
+    Iterates *known_unions* in order; returns the first whose name appears
+    (case-insensitively) as a substring of *query*. Returns None when no
+    match is found.
+    """
+    lower = query.lower()
+    for union in known_unions:
+        if union.lower() in lower:
+            return union
+    return None
+
+
+def detect_scope(query: str) -> str | None:
+    """Return 'generation' or 'transmission' if the corresponding word appears.
+
+    Word-boundary matching prevents false positives from words that merely
+    contain 'generation' or 'transmission' as a substring (e.g. 'regeneration',
+    'retransmission'). 'generation' is checked first; if both words appear,
+    'generation' is returned.
+
+    Relevant for IBEW and Labourers agreements, which are scoped by site type.
+    Returns None when neither word is present.
+    """
+    if _SCOPE_PATTERNS["generation"].search(query):
+        return "generation"
+    if _SCOPE_PATTERNS["transmission"].search(query):
+        return "transmission"
+    return None
+
+
+def classify_complexity(query: str) -> bool:
+    """Return True if the query contains cross-union comparison language.
+
+    True triggers routing to Claude Sonnet; False routes to Claude Haiku.
+    """
+    lower = query.lower()
+    return any(phrase in lower for phrase in _CROSS_UNION_PHRASES)
+
+
+def preprocess(query: str, known_unions: list[str]) -> QueryContext:
+    """Analyse *query* and return a populated QueryContext.
+
+    Args:
+        query: The raw user query string.
+        known_unions: Union names to match against, typically sourced from
+            the database or corpus manifest at request time.
+
+    Returns:
+        A QueryContext describing retrieval filters and model routing.
+    """
+    return QueryContext(
+        union_filter=detect_union(query, known_unions),
+        include_nuclear_pa=detect_nuclear(query),
+        agreement_scope=detect_scope(query),
+        is_cross_union=classify_complexity(query),
+    )

--- a/services/api/tests/test_preprocess.py
+++ b/services/api/tests/test_preprocess.py
@@ -1,0 +1,245 @@
+from src.rag.preprocess import (
+    NUCLEAR_KEYWORDS,
+    QueryContext,
+    classify_complexity,
+    detect_nuclear,
+    detect_scope,
+    detect_union,
+    preprocess,
+)
+
+KNOWN_UNIONS = [
+    "IBEW",
+    "Sheet Metal Workers",
+    "United Association",
+    "Labourers",
+]
+
+
+class TestNuclearKeywords:
+    def test_constant_contains_required_entries(self) -> None:
+        required = [
+            "nuclear",
+            "OPG",
+            "Ontario Power Generation",
+            "Bruce Power",
+            "Darlington",
+            "Pickering",
+            "nuclear project",
+            "NPA",
+        ]
+        for kw in required:
+            assert kw in NUCLEAR_KEYWORDS
+
+
+class TestDetectNuclear:
+    def test_empty_query_returns_false(self) -> None:
+        assert detect_nuclear("") is False
+
+    def test_no_keywords_returns_false(self) -> None:
+        assert detect_nuclear("What is the overtime rate for IBEW?") is False
+
+    def test_detects_nuclear_lowercase(self) -> None:
+        assert detect_nuclear("is nuclear work covered?") is True
+
+    def test_detects_nuclear_uppercase(self) -> None:
+        assert detect_nuclear("NUCLEAR project rules") is True
+
+    def test_detects_opg(self) -> None:
+        assert detect_nuclear("What does OPG require for site access?") is True
+
+    def test_detects_ontario_power_generation(self) -> None:
+        assert detect_nuclear("Ontario Power Generation safety standards") is True
+
+    def test_detects_bruce_power(self) -> None:
+        assert detect_nuclear("Bruce Power overtime provisions") is True
+
+    def test_detects_darlington(self) -> None:
+        assert detect_nuclear("Darlington refurbishment wage rates") is True
+
+    def test_detects_pickering(self) -> None:
+        assert detect_nuclear("Pickering decommissioning schedule") is True
+
+    def test_detects_nuclear_project(self) -> None:
+        assert detect_nuclear("nuclear project agreement scope") is True
+
+    def test_detects_npa(self) -> None:
+        assert detect_nuclear("What does the NPA say about layoffs?") is True
+
+    def test_case_insensitive_mixed(self) -> None:
+        assert detect_nuclear("What are the nPa provisions?") is True
+
+    def test_opg_lowercase(self) -> None:
+        assert detect_nuclear("opg site badge requirements") is True
+
+    def test_npa_requires_word_boundary(self) -> None:
+        # "npa" embedded mid-word should not match
+        assert detect_nuclear("the company's cnpa policy does not apply") is False
+
+    def test_non_nuclear_does_not_trigger(self) -> None:
+        # "non-nuclear" contains "nuclear" as substring but should still match
+        # because "nuclear" is its own token here
+        assert detect_nuclear("this is a non-nuclear facility") is True
+
+
+class TestDetectUnion:
+    def test_empty_query_returns_none(self) -> None:
+        assert detect_union("", KNOWN_UNIONS) is None
+
+    def test_empty_known_unions_returns_none(self) -> None:
+        assert detect_union("IBEW overtime rates", []) is None
+
+    def test_detects_ibew_exact_case(self) -> None:
+        assert detect_union("What does IBEW say about overtime?", KNOWN_UNIONS) == "IBEW"
+
+    def test_detects_ibew_lowercase(self) -> None:
+        assert detect_union("ibew overtime rates", KNOWN_UNIONS) == "IBEW"
+
+    def test_detects_multiword_union(self) -> None:
+        result = detect_union("Sheet Metal Workers vacation entitlement", KNOWN_UNIONS)
+        assert result == "Sheet Metal Workers"
+
+    def test_detects_united_association(self) -> None:
+        result = detect_union("united association pipe fitting rates", KNOWN_UNIONS)
+        assert result == "United Association"
+
+    def test_returns_verbatim_union_name(self) -> None:
+        # 'ibew' in query → return 'IBEW' (from known_unions, not query case)
+        result = detect_union("ibew rules", KNOWN_UNIONS)
+        assert result == "IBEW"
+
+    def test_returns_first_union_in_known_unions_order(self) -> None:
+        # Query contains both IBEW and Labourers; IBEW is first in known_unions
+        result = detect_union("IBEW and Labourers overtime rules", KNOWN_UNIONS)
+        assert result == "IBEW"
+
+    def test_query_with_no_union_returns_none(self) -> None:
+        assert detect_union("general overtime rules for all workers", KNOWN_UNIONS) is None
+
+
+class TestDetectScope:
+    def test_no_scope_returns_none(self) -> None:
+        assert detect_scope("What is the overtime rate?") is None
+
+    def test_empty_query_returns_none(self) -> None:
+        assert detect_scope("") is None
+
+    def test_detects_generation(self) -> None:
+        assert detect_scope("generation plant overtime") == "generation"
+
+    def test_detects_transmission(self) -> None:
+        assert detect_scope("transmission line work rules") == "transmission"
+
+    def test_generation_uppercase(self) -> None:
+        assert detect_scope("GENERATION facility wage schedule") == "generation"
+
+    def test_transmission_uppercase(self) -> None:
+        assert detect_scope("TRANSMISSION corridor rules") == "transmission"
+
+    def test_generation_mixed_case(self) -> None:
+        assert detect_scope("Generation workers shift premium") == "generation"
+
+    def test_returns_generation_when_both_present(self) -> None:
+        # generation check precedes transmission in detect_scope; generation wins
+        result = detect_scope("generation and transmission overtime")
+        assert result == "generation"
+
+    def test_regeneration_does_not_trigger_generation(self) -> None:
+        assert detect_scope("regeneration clause in article 12") is None
+
+    def test_retransmission_does_not_trigger_transmission(self) -> None:
+        assert detect_scope("retransmission rights are excluded") is None
+
+
+class TestClassifyComplexity:
+    def test_simple_query_returns_false(self) -> None:
+        assert classify_complexity("What is the overtime rate for IBEW?") is False
+
+    def test_empty_query_returns_false(self) -> None:
+        assert classify_complexity("") is False
+
+    def test_compare_returns_true(self) -> None:
+        assert classify_complexity("compare IBEW and UA overtime rules") is True
+
+    def test_difference_between_returns_true(self) -> None:
+        assert classify_complexity("what is the difference between IBEW and UA?") is True
+
+    def test_all_unions_returns_true(self) -> None:
+        assert classify_complexity("what do all unions say about vacation?") is True
+
+    def test_across_trades_returns_true(self) -> None:
+        assert classify_complexity("shift premiums across trades") is True
+
+    def test_compare_uppercase(self) -> None:
+        assert classify_complexity("COMPARE the two agreements") is True
+
+    def test_difference_between_uppercase(self) -> None:
+        assert classify_complexity("DIFFERENCE BETWEEN IBEW and UA") is True
+
+
+class TestQueryContext:
+    def test_default_values(self) -> None:
+        ctx = QueryContext(
+            union_filter=None,
+            include_nuclear_pa=False,
+            agreement_scope=None,
+            is_cross_union=False,
+        )
+        assert ctx.union_filter is None
+        assert ctx.include_nuclear_pa is False
+        assert ctx.agreement_scope is None
+        assert ctx.is_cross_union is False
+
+    def test_all_fields_set(self) -> None:
+        ctx = QueryContext(
+            union_filter="IBEW",
+            include_nuclear_pa=True,
+            agreement_scope="generation",
+            is_cross_union=True,
+        )
+        assert ctx.union_filter == "IBEW"
+        assert ctx.include_nuclear_pa is True
+        assert ctx.agreement_scope == "generation"
+        assert ctx.is_cross_union is True
+
+
+class TestPreprocess:
+    def test_simple_query_returns_all_defaults(self) -> None:
+        ctx = preprocess("What is the overtime rate?", KNOWN_UNIONS)
+        assert ctx.union_filter is None
+        assert ctx.include_nuclear_pa is False
+        assert ctx.agreement_scope is None
+        assert ctx.is_cross_union is False
+
+    def test_nuclear_query_sets_include_nuclear_pa(self) -> None:
+        ctx = preprocess("OPG site badge requirements", KNOWN_UNIONS)
+        assert ctx.include_nuclear_pa is True
+
+    def test_union_query_sets_union_filter(self) -> None:
+        ctx = preprocess("What does IBEW say about overtime?", KNOWN_UNIONS)
+        assert ctx.union_filter == "IBEW"
+
+    def test_scope_query_sets_agreement_scope(self) -> None:
+        ctx = preprocess("generation plant shift schedule", KNOWN_UNIONS)
+        assert ctx.agreement_scope == "generation"
+
+    def test_cross_union_query_sets_is_cross_union(self) -> None:
+        ctx = preprocess("compare IBEW and UA overtime rules", KNOWN_UNIONS)
+        assert ctx.is_cross_union is True
+
+    def test_combined_nuclear_and_union(self) -> None:
+        ctx = preprocess("IBEW Darlington refurbishment wage rates", KNOWN_UNIONS)
+        assert ctx.union_filter == "IBEW"
+        assert ctx.include_nuclear_pa is True
+
+    def test_combined_all_flags(self) -> None:
+        ctx = preprocess(
+            "compare all unions at OPG generation facilities", KNOWN_UNIONS
+        )
+        assert ctx.include_nuclear_pa is True
+        assert ctx.agreement_scope == "generation"
+        assert ctx.is_cross_union is True
+
+    def test_returns_query_context_type(self) -> None:
+        ctx = preprocess("overtime rates", KNOWN_UNIONS)
+        assert isinstance(ctx, QueryContext)


### PR DESCRIPTION
## Summary

- Add `services/api/src/rag/preprocess.py` implementing the five components specified in `docs/planning.md §7 Step 1`
- `NUCLEAR_KEYWORDS` constant + `detect_nuclear` with word-boundary regex (avoids false positives from embedded substrings like `cnpa`)
- `detect_union` — case-insensitive substring scan returning verbatim union name from caller-supplied list
- `detect_scope` — word-boundary regex for `generation` / `transmission` (correctly rejects `regeneration`, `retransmission`)
- `classify_complexity` — detects cross-union comparison phrases to route to Claude Sonnet
- `QueryContext` pydantic v2 model aggregating all four detector outputs
- `preprocess(query, known_unions)` orchestrator returning `QueryContext`

## Test plan

- [ ] 53 unit tests in `tests/test_preprocess.py` — positive, negative, case-insensitive, word-boundary, and combined-flag cases for every detector
- [ ] `python3 -m pytest -q` → 67 passed (53 new + 14 existing health tests)
- [ ] `ruff check` → no issues
- [ ] `mypy src/rag/preprocess.py` → no issues (strict mode)
- [ ] python-reviewer agent review addressed: added word-boundary regex for scope/nuclear, fixed weak assertion in scope priority test, added boundary negative tests

Closes #15