### PR TITLE
feat(api): implement POST /query endpoint with model routing and response structure

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -42,7 +42,7 @@ Goal: End-to-end pipeline validated against 3 unions (IBEW Generation, Sheet Met
 | [#14](https://github.com/BoilerHAUS/EPSCAxplor/issues/14) | no-pr | [x] | ops: run Phase 1 POC ingestion (IBEW Generation, Sheet Metal, UA) |
 | [#15](https://github.com/BoilerHAUS/EPSCAxplor/issues/15) | pr | [x] | feat(rag): implement query pre-processing (nuclear detection, union/scope detection) |
 | [#16](https://github.com/BoilerHAUS/EPSCAxplor/issues/16) | pr | [x] | feat(rag): implement Qdrant filtered similarity search and context assembly |
-| [#17](https://github.com/BoilerHAUS/EPSCAxplor/issues/17) | pr | [ ] | feat(api): implement POST /query endpoint with model routing and response structure |
+| [#17](https://github.com/BoilerHAUS/EPSCAxplor/issues/17) | pr | [x] | feat(api): implement POST /query endpoint with model routing and response structure |
 | [#18](https://github.com/BoilerHAUS/EPSCAxplor/issues/18) | no-pr | [ ] | ops: evaluate Phase 1 POC against gold question set |
 | [#39](https://github.com/BoilerHAUS/EPSCAxplor/issues/39) | pr | [x] | chore(ci): extract shared validation steps into reusable workflow |
 

--- a/services/api/src/auth/__init__.py
+++ b/services/api/src/auth/__init__.py
@@ -1,0 +1,25 @@
+"""Auth module — Phase 1 stub.
+
+Provides a get_current_user FastAPI dependency that accepts all requests
+without JWT validation.  Auth enforcement is added in a later phase.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel
+
+# Hardcoded system tenant UUID used for query logging until real auth is active.
+# Must be seeded in the tenants table before query_logs writes succeed.
+SYSTEM_TENANT_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+class CurrentUser(BaseModel):
+    tenant_id: uuid.UUID
+    user_id: uuid.UUID | None = None
+
+
+async def get_current_user() -> CurrentUser:
+    """Stub dependency — returns the system tenant with no user."""
+    return CurrentUser(tenant_id=SYSTEM_TENANT_ID)

--- a/services/api/src/main.py
+++ b/services/api/src/main.py
@@ -1,10 +1,13 @@
+import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from src.config import get_settings
 from src.routes.health import router as health_router
+from src.routes.query import router as query_router
 
 
 @asynccontextmanager
@@ -15,4 +18,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(title="EPSCAxplor API", lifespan=lifespan)
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=os.getenv("CORS_ORIGINS", "http://localhost:3000").split(","),
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type", "Authorization"],
+)
+
 app.include_router(health_router)
+app.include_router(query_router)

--- a/services/api/src/rag/citation_extractor.py
+++ b/services/api/src/rag/citation_extractor.py
@@ -1,0 +1,78 @@
+"""Citation extraction — Step 5b of the EPSCAxplor query pipeline.
+
+Parses [SOURCE N] markers from the generated answer and maps each to
+the corresponding retrieved chunk, producing structured CitationRef objects.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel
+
+from src.rag.retrieval import ChunkResult
+
+_SOURCE_PATTERN: re.Pattern[str] = re.compile(r"\[SOURCE\s+(\d+)\]", re.IGNORECASE)
+
+
+class CitationRef(BaseModel):
+    source_number: int
+    union_name: str
+    document_title: str
+    document_type: str
+    effective_date: str | None
+    article: str | None
+    section: str | None
+    article_title: str | None
+    page_number: int | None
+    excerpt: str
+
+
+def extract_citations(
+    answer: str,
+    chunks: list[ChunkResult],
+    title_map: dict[str, str] | None = None,
+) -> list[CitationRef]:
+    """Extract structured citations from an answer referencing retrieved chunks.
+
+    Finds all [SOURCE N] patterns in *answer* and maps each to the chunk at
+    index N-1.  References to out-of-range indices are silently ignored.
+    Duplicate source numbers are deduplicated; results are sorted ascending
+    by source_number.
+
+    Args:
+        answer: Generated text from Claude containing [SOURCE N] markers.
+        chunks: Chunks in the same order passed to assemble_context() (1-indexed).
+        title_map: Optional document_id → human-readable title mapping.
+
+    Returns:
+        List of CitationRef objects, one per unique referenced source.
+    """
+    resolved: dict[str, str] = title_map or {}
+    seen: set[int] = set()
+    citations: list[CitationRef] = []
+
+    for match in _SOURCE_PATTERN.finditer(answer):
+        n = int(match.group(1))
+        if n in seen or n < 1 or n > len(chunks):
+            continue
+        seen.add(n)
+        chunk = chunks[n - 1]
+        title = resolved.get(chunk.document_id) or chunk.source_filename
+        citations.append(
+            CitationRef(
+                source_number=n,
+                union_name=chunk.union_name,
+                document_title=title,
+                document_type=chunk.document_type,
+                effective_date=chunk.effective_date,
+                article=chunk.article_number,
+                section=chunk.section_number,
+                article_title=chunk.article_title,
+                page_number=chunk.page_number,
+                excerpt=chunk.text,
+            )
+        )
+
+    citations.sort(key=lambda c: c.source_number)
+    return citations

--- a/services/api/src/rag/generator.py
+++ b/services/api/src/rag/generator.py
@@ -1,0 +1,145 @@
+"""RAG generation layer — Step 4 of the EPSCAxplor query pipeline.
+
+Calls Claude with the assembled context and system prompt, returning
+the generated answer with token usage and latency.
+
+Prompt caching is enabled: the system prompt is passed as a cached
+TextBlock so repeated calls within the 5-minute TTL avoid re-billing
+for system-prompt tokens.
+"""
+
+from __future__ import annotations
+
+import time
+
+import anthropic
+from anthropic.types import TextBlock
+from pydantic import BaseModel
+
+from src.config import Settings
+
+DISCLAIMER = (
+    "This answer is for reference only and does not constitute legal advice. "
+    "Consult qualified labour relations counsel for binding interpretations."
+)
+
+_STANDARD_SYSTEM_PROMPT = """\
+You are EPSCAxplor, a specialist reference assistant for EPSCA collective agreements \
+covering construction trade unions in Ontario, Canada.
+
+Your job is to answer questions about collective agreement terms, wages, working \
+conditions, and labour relations using only the source documents provided in this \
+conversation. You do not use general knowledge. You do not guess. You do not infer \
+beyond what the documents state.
+
+CITATION RULES — these are non-negotiable:
+
+1. Every factual claim in your answer must be attributed to a specific source using \
+   the format [SOURCE N] where N matches the source number in the provided context.
+
+2. You must identify the specific article and section number for every cited claim. \
+   If a source does not clearly show an article or section number, cite the document \
+   title and page number instead.
+
+3. If two sources say different things about the same topic (for example, a Primary CA \
+   and a Nuclear Project Agreement), you must surface the conflict explicitly and explain \
+   which document governs which context.
+
+4. Never combine information from multiple sources into a single unattributed statement.
+
+REFUSAL RULES:
+
+5. If the answer to a question is not present in the provided sources, say so directly: \
+   "The provided documents do not contain information about [topic]." Do not speculate \
+   or draw on general knowledge to fill the gap.
+
+6. If the question requires a legal interpretation or advice about which party is right \
+   in a dispute, decline to make that determination. Provide the relevant clause text \
+   and note that interpretation is a matter for qualified labour relations counsel.
+
+ANSWER FORMAT:
+
+- Lead with a direct answer to the question.
+- Follow with the supporting clause text and citation.
+- End every response with this exact disclaimer on its own line:
+  "\u26a0\ufe0f This answer is for reference only and does not constitute legal advice."
+
+Provided sources follow."""
+
+_COMPARISON_ADDENDUM = """
+
+COMPARISON RULES:
+
+When comparing provisions across multiple unions:
+- Address each union's position separately before summarizing differences.
+- Use a consistent structure: [Union Name]: [provision], citing [SOURCE N].
+- If a union's agreement is silent on a topic that other agreements address explicitly, \
+  note the absence — do not assume the provision does not exist."""
+
+
+def build_system_prompt(is_cross_union: bool) -> str:
+    """Return the appropriate system prompt based on query complexity."""
+    if is_cross_union:
+        return _STANDARD_SYSTEM_PROMPT + _COMPARISON_ADDENDUM
+    return _STANDARD_SYSTEM_PROMPT
+
+
+class GeneratorResult(BaseModel):
+    answer: str
+    model_used: str
+    prompt_tokens: int
+    completion_tokens: int
+    latency_ms: int
+
+
+async def generate(
+    query: str,
+    context: str,
+    *,
+    is_cross_union: bool,
+    settings: Settings,
+) -> GeneratorResult:
+    """Call Claude with the query and assembled context, returning a GeneratorResult.
+
+    Args:
+        query: Raw user question.
+        context: Assembled source blocks from assemble_context().
+        is_cross_union: Routes to Sonnet when True, Haiku when False.
+        settings: Application settings (API key, model IDs).
+
+    Returns:
+        GeneratorResult with answer text, model, token counts, and latency.
+    """
+    model = (
+        settings.claude_sonnet_model if is_cross_union else settings.claude_haiku_model
+    )
+    system_prompt = build_system_prompt(is_cross_union)
+    user_content = f"{query}\n\n{context}" if context else query
+
+    start = time.monotonic()
+    async with anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key) as client:
+        response = await client.messages.create(
+            model=model,
+            max_tokens=2048,
+            system=[
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": user_content}],
+        )
+    latency_ms = int((time.monotonic() - start) * 1000)
+
+    first_block = response.content[0]
+    if not isinstance(first_block, TextBlock):
+        raise ValueError(f"Unexpected content block type: {type(first_block)}")
+
+    return GeneratorResult(
+        answer=first_block.text,
+        model_used=model,
+        prompt_tokens=response.usage.input_tokens,
+        completion_tokens=response.usage.output_tokens,
+        latency_ms=latency_ms,
+    )

--- a/services/api/src/routes/query.py
+++ b/services/api/src/routes/query.py
@@ -1,0 +1,196 @@
+"""POST /query route — core RAG pipeline endpoint.
+
+Wires together pre-processing, retrieval, context assembly, generation,
+citation extraction, query logging, and the structured response.
+
+Phase 1 notes:
+- Auth is a stub (no JWT enforcement).
+- Query log writes are best-effort: a FK violation on tenant_id (absent
+  system tenant in DB) will not fail the response; query_log_id is None.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from typing import Annotated, Any
+
+import asyncpg
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field, field_validator
+
+from src.auth import CurrentUser, get_current_user
+from src.config import Settings, get_settings
+from src.rag.citation_extractor import CitationRef, extract_citations
+from src.rag.context import assemble_context
+from src.rag.generator import DISCLAIMER, GeneratorResult, generate
+from src.rag.preprocess import QueryContext, preprocess
+from src.rag.retrieval import ChunkResult, retrieve
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class QueryRequest(BaseModel):
+    query: str = Field(min_length=1, max_length=2000)
+
+    @field_validator("query")
+    @classmethod
+    def query_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("query must not be blank")
+        return v
+
+
+class QueryResponse(BaseModel):
+    answer: str
+    citations: list[CitationRef]
+    model_used: str
+    disclaimer: str
+    query_log_id: str | None
+
+
+async def _get_known_unions(database_url: str) -> list[str]:
+    """Return distinct union names from the documents table."""
+    conn = await asyncpg.connect(database_url, timeout=5)
+    try:
+        rows = await conn.fetch("SELECT DISTINCT union_name FROM documents ORDER BY union_name")
+        return [row["union_name"] for row in rows]
+    finally:
+        await conn.close()
+
+
+async def _get_title_map(database_url: str, doc_ids: list[str]) -> dict[str, str]:
+    """Return a document_id → title mapping for the given UUIDs."""
+    if not doc_ids:
+        return {}
+    conn = await asyncpg.connect(database_url, timeout=5)
+    try:
+        rows = await conn.fetch(
+            "SELECT id::text, title FROM documents WHERE id = ANY($1::uuid[])",
+            doc_ids,
+        )
+        return {row["id"]: row["title"] for row in rows}
+    finally:
+        await conn.close()
+
+
+async def _write_query_log(
+    database_url: str,
+    *,
+    tenant_id: uuid.UUID,
+    user_id: uuid.UUID | None,
+    query_text: str,
+    response_text: str,
+    model_used: str,
+    union_filter: list[str] | None,
+    doc_type_filter: list[str] | None,
+    chunks_retrieved: int,
+    prompt_tokens: int,
+    completion_tokens: int,
+    latency_ms: int,
+    citations: list[dict[str, Any]],
+) -> str | None:
+    """Insert a row into query_logs; return the new UUID or None on error."""
+    try:
+        conn = await asyncpg.connect(database_url, timeout=5)
+        try:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO query_logs (
+                    tenant_id, user_id, query_text, response_text, model_used,
+                    union_filter, doc_type_filter, chunks_retrieved,
+                    prompt_tokens, completion_tokens, latency_ms, citations
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                RETURNING id::text
+                """,
+                tenant_id,
+                user_id,
+                query_text,
+                response_text,
+                model_used,
+                union_filter,
+                doc_type_filter,
+                chunks_retrieved,
+                prompt_tokens,
+                completion_tokens,
+                latency_ms,
+                json.dumps(citations),
+            )
+            return row["id"] if row else None
+        finally:
+            await conn.close()
+    except Exception:  # noqa: BLE001
+        logger.warning("query_log write failed (best-effort)", exc_info=True)
+        return None
+
+
+@router.post("/query", response_model=QueryResponse)
+async def query_handler(
+    body: QueryRequest,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> QueryResponse:
+    """Execute the full RAG pipeline for a user query."""
+    pipeline_start = time.monotonic()
+
+    # Step 1 — pre-process
+    known_unions = await _get_known_unions(settings.database_url)
+    ctx: QueryContext = preprocess(body.query, known_unions)
+
+    # Step 2 — retrieve
+    chunks: list[ChunkResult] = await retrieve(
+        body.query,
+        union_filter=ctx.union_filter,
+        include_nuclear_pa=ctx.include_nuclear_pa,
+        agreement_scope=ctx.agreement_scope,
+        settings=settings,
+    )
+
+    # Step 3 — assemble context (with title lookup)
+    doc_ids = list({c.document_id for c in chunks})
+    title_map = await _get_title_map(settings.database_url, doc_ids)
+    context_block = assemble_context(chunks, title_map=title_map)
+
+    # Step 4 — generate
+    result: GeneratorResult = await generate(
+        body.query,
+        context_block,
+        is_cross_union=ctx.is_cross_union,
+        settings=settings,
+    )
+
+    # Step 5 — extract citations
+    citations = extract_citations(result.answer, chunks, title_map=title_map)
+
+    # Step 6 — log query (best-effort)
+    union_filter_list = [ctx.union_filter] if ctx.union_filter else None
+    doc_type_filter_list = None if ctx.include_nuclear_pa else ["primary_ca"]
+    total_latency_ms = int((time.monotonic() - pipeline_start) * 1000)
+
+    query_log_id = await _write_query_log(
+        settings.database_url,
+        tenant_id=current_user.tenant_id,
+        user_id=current_user.user_id,
+        query_text=body.query,
+        response_text=result.answer,
+        model_used=result.model_used,
+        union_filter=union_filter_list,
+        doc_type_filter=doc_type_filter_list,
+        chunks_retrieved=len(chunks),
+        prompt_tokens=result.prompt_tokens,
+        completion_tokens=result.completion_tokens,
+        latency_ms=total_latency_ms,
+        citations=[c.model_dump() for c in citations],
+    )
+
+    return QueryResponse(
+        answer=result.answer,
+        citations=citations,
+        model_used=result.model_used,
+        disclaimer=DISCLAIMER,
+        query_log_id=query_log_id,
+    )

--- a/services/api/tests/test_citation_extractor.py
+++ b/services/api/tests/test_citation_extractor.py
@@ -1,0 +1,166 @@
+"""Tests for services/api/src/rag/citation_extractor.py.
+
+Covers:
+- extract_citations: basic [SOURCE N] extraction
+- extract_citations: deduplication of repeated references
+- extract_citations: out-of-range source numbers ignored
+- extract_citations: case-insensitive matching
+- extract_citations: sorted ascending by source_number
+- extract_citations: title_map applied over source_filename
+- extract_citations: empty answer and empty chunks edge cases
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.rag.citation_extractor import CitationRef, extract_citations
+from src.rag.retrieval import ChunkResult
+
+
+def make_chunk(
+    *,
+    document_id: str = "doc-001",
+    source_filename: str = "IBEW_CA_2025.pdf",
+    union_name: str = "IBEW",
+    document_type: str = "primary_ca",
+    effective_date: str | None = "2025-05-01",
+    expiry_date: str | None = "2030-04-30",
+    article_number: str | None = "Article 12",
+    article_title: str | None = "Overtime",
+    section_number: str | None = "12.03",
+    page_number: int | None = 34,
+    text: str = "Overtime shall be paid at time and one-half.",
+) -> ChunkResult:
+    return ChunkResult(
+        point_id="pt-001",
+        score=0.9,
+        document_id=document_id,
+        source_filename=source_filename,
+        union_name=union_name,
+        document_type=document_type,
+        agreement_scope=None,
+        effective_date=effective_date,
+        expiry_date=expiry_date,
+        article_number=article_number,
+        article_title=article_title,
+        section_number=section_number,
+        page_number=page_number,
+        is_table=False,
+        text=text,
+    )
+
+
+# ─── Basic extraction ─────────────────────────────────────────────────────────
+
+
+def test_single_source_extracted() -> None:
+    chunk = make_chunk()
+    result = extract_citations("See [SOURCE 1] for details.", [chunk])
+    assert len(result) == 1
+    assert result[0].source_number == 1
+    assert result[0].union_name == "IBEW"
+    assert result[0].article == "Article 12"
+    assert result[0].section == "12.03"
+    assert result[0].excerpt == chunk.text
+
+
+def test_multiple_sources_extracted() -> None:
+    c1 = make_chunk(union_name="IBEW", text="IBEW clause")
+    c2 = make_chunk(union_name="UA", document_id="doc-002", text="UA clause")
+    answer = "See [SOURCE 1] and [SOURCE 2]."
+    result = extract_citations(answer, [c1, c2])
+    assert len(result) == 2
+    assert result[0].source_number == 1
+    assert result[1].source_number == 2
+
+
+def test_sorted_ascending() -> None:
+    c1 = make_chunk(union_name="IBEW")
+    c2 = make_chunk(union_name="UA", document_id="doc-002")
+    answer = "[SOURCE 2] then [SOURCE 1]"
+    result = extract_citations(answer, [c1, c2])
+    assert [c.source_number for c in result] == [1, 2]
+
+
+# ─── Deduplication ───────────────────────────────────────────────────────────
+
+
+def test_duplicate_references_deduplicated() -> None:
+    chunk = make_chunk()
+    answer = "[SOURCE 1] confirms this. As noted in [SOURCE 1], it applies."
+    result = extract_citations(answer, [chunk])
+    assert len(result) == 1
+
+
+# ─── Out-of-range ─────────────────────────────────────────────────────────────
+
+
+def test_out_of_range_source_ignored() -> None:
+    chunk = make_chunk()
+    result = extract_citations("[SOURCE 5] is cited.", [chunk])
+    assert result == []
+
+
+def test_source_zero_ignored() -> None:
+    chunk = make_chunk()
+    result = extract_citations("[SOURCE 0]", [chunk])
+    assert result == []
+
+
+# ─── Case-insensitive ─────────────────────────────────────────────────────────
+
+
+def test_case_insensitive_match() -> None:
+    chunk = make_chunk()
+    result = extract_citations("[source 1] is referenced.", [chunk])
+    assert len(result) == 1
+
+
+# ─── title_map ────────────────────────────────────────────────────────────────
+
+
+def test_title_map_overrides_source_filename() -> None:
+    chunk = make_chunk(document_id="doc-001", source_filename="IBEW_CA_2025.pdf")
+    title_map = {"doc-001": "IBEW Generation 2025-2030 Collective Agreement"}
+    result = extract_citations("[SOURCE 1]", [chunk], title_map=title_map)
+    assert result[0].document_title == "IBEW Generation 2025-2030 Collective Agreement"
+
+
+def test_missing_title_falls_back_to_filename() -> None:
+    chunk = make_chunk(document_id="doc-001", source_filename="fallback.pdf")
+    result = extract_citations("[SOURCE 1]", [chunk], title_map=None)
+    assert result[0].document_title == "fallback.pdf"
+
+
+# ─── Edge cases ───────────────────────────────────────────────────────────────
+
+
+def test_empty_answer_returns_empty() -> None:
+    assert extract_citations("", [make_chunk()]) == []
+
+
+def test_empty_chunks_returns_empty() -> None:
+    assert extract_citations("[SOURCE 1]", []) == []
+
+
+def test_no_source_markers_returns_empty() -> None:
+    assert extract_citations("No sources cited here.", [make_chunk()]) == []
+
+
+def test_optional_fields_none() -> None:
+    chunk = make_chunk(article_number=None, section_number=None, article_title=None, page_number=None)
+    result = extract_citations("[SOURCE 1]", [chunk])
+    assert result[0].article is None
+    assert result[0].section is None
+    assert result[0].article_title is None
+    assert result[0].page_number is None
+
+
+def test_citation_ref_model_fields() -> None:
+    chunk = make_chunk()
+    result = extract_citations("[SOURCE 1]", [chunk])
+    ref = result[0]
+    assert isinstance(ref, CitationRef)
+    assert ref.document_type == "primary_ca"
+    assert ref.effective_date == "2025-05-01"

--- a/services/api/tests/test_generator.py
+++ b/services/api/tests/test_generator.py
@@ -1,0 +1,152 @@
+"""Tests for services/api/src/rag/generator.py.
+
+Covers:
+- build_system_prompt: standard vs cross-union variants
+- generate: happy path via mocked AsyncAnthropic
+- generate: uses Sonnet for cross-union, Haiku for standard
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from anthropic.types import TextBlock, Usage
+
+from src.config import Settings
+from src.rag.generator import DISCLAIMER, GeneratorResult, build_system_prompt, generate
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        database_url="postgresql://user:pass@localhost/epsca",
+        qdrant_url="http://localhost:6333",
+        ollama_url="http://localhost:11434",
+        anthropic_api_key="test-key",
+        jwt_secret="test-jwt-secret",  # noqa: S106
+    )
+
+
+# ─── build_system_prompt ──────────────────────────────────────────────────────
+
+
+def test_standard_prompt_contains_citation_rules() -> None:
+    prompt = build_system_prompt(is_cross_union=False)
+    assert "CITATION RULES" in prompt
+    assert "COMPARISON RULES" not in prompt
+
+
+def test_cross_union_prompt_appends_comparison_rules() -> None:
+    prompt = build_system_prompt(is_cross_union=True)
+    assert "CITATION RULES" in prompt
+    assert "COMPARISON RULES" in prompt
+
+
+def test_standard_prompt_ends_with_sources_follow() -> None:
+    prompt = build_system_prompt(is_cross_union=False)
+    assert prompt.endswith("Provided sources follow.")
+
+
+def test_cross_union_prompt_ends_with_comparison_addendum() -> None:
+    prompt = build_system_prompt(is_cross_union=True)
+    assert "note the absence" in prompt
+
+
+# ─── DISCLAIMER ───────────────────────────────────────────────────────────────
+
+
+def test_disclaimer_content() -> None:
+    assert "reference only" in DISCLAIMER
+    assert "legal advice" in DISCLAIMER
+
+
+# ─── generate ─────────────────────────────────────────────────────────────────
+
+
+def _make_mock_response(text: str, input_tokens: int = 100, output_tokens: int = 50) -> MagicMock:
+    block = TextBlock(type="text", text=text)
+    usage = MagicMock(spec=Usage)
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+    response = MagicMock()
+    response.content = [block]
+    response.usage = usage
+    return response
+
+
+def _mock_client(mock_create: AsyncMock) -> MagicMock:
+    """Return a mock AsyncAnthropic instance wired as an async context manager."""
+    instance = MagicMock()
+    instance.__aenter__ = AsyncMock(return_value=instance)
+    instance.__aexit__ = AsyncMock(return_value=False)
+    instance.messages.create = mock_create
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_generate_standard_uses_haiku(settings: Settings) -> None:
+    mock_response = _make_mock_response("Standard answer [SOURCE 1]")
+    mock_create = AsyncMock(return_value=mock_response)
+
+    with patch("src.rag.generator.anthropic.AsyncAnthropic", return_value=_mock_client(mock_create)):
+        result = await generate("What is overtime?", "context", is_cross_union=False, settings=settings)
+
+    assert result.model_used == settings.claude_haiku_model
+    assert result.answer == "Standard answer [SOURCE 1]"
+    assert result.prompt_tokens == 100
+    assert result.completion_tokens == 50
+    assert result.latency_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_generate_cross_union_uses_sonnet(settings: Settings) -> None:
+    mock_response = _make_mock_response("Compare answer [SOURCE 1] vs [SOURCE 2]")
+    mock_create = AsyncMock(return_value=mock_response)
+
+    with patch("src.rag.generator.anthropic.AsyncAnthropic", return_value=_mock_client(mock_create)):
+        result = await generate(
+            "Compare overtime across unions", "context", is_cross_union=True, settings=settings
+        )
+
+    assert result.model_used == settings.claude_sonnet_model
+
+
+@pytest.mark.asyncio
+async def test_generate_empty_context_sends_query_only(settings: Settings) -> None:
+    mock_response = _make_mock_response("No docs found")
+    mock_create = AsyncMock(return_value=mock_response)
+
+    with patch("src.rag.generator.anthropic.AsyncAnthropic", return_value=_mock_client(mock_create)):
+        await generate("What is overtime?", "", is_cross_union=False, settings=settings)
+
+    call_args = mock_create.call_args
+    messages = call_args.kwargs["messages"]
+    assert messages[0]["content"] == "What is overtime?"
+
+
+@pytest.mark.asyncio
+async def test_generate_system_prompt_cached(settings: Settings) -> None:
+    mock_response = _make_mock_response("Answer")
+    mock_create = AsyncMock(return_value=mock_response)
+
+    with patch("src.rag.generator.anthropic.AsyncAnthropic", return_value=_mock_client(mock_create)):
+        await generate("query", "ctx", is_cross_union=False, settings=settings)
+
+    call_args = mock_create.call_args
+    system_blocks = call_args.kwargs["system"]
+    assert isinstance(system_blocks, list)
+    assert system_blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_generator_result(settings: Settings) -> None:
+    mock_response = _make_mock_response("Answer", input_tokens=200, output_tokens=80)
+    mock_create = AsyncMock(return_value=mock_response)
+
+    with patch("src.rag.generator.anthropic.AsyncAnthropic", return_value=_mock_client(mock_create)):
+        result = await generate("q", "ctx", is_cross_union=False, settings=settings)
+
+    assert isinstance(result, GeneratorResult)
+    assert result.prompt_tokens == 200
+    assert result.completion_tokens == 80

--- a/services/api/tests/test_query_route.py
+++ b/services/api/tests/test_query_route.py
@@ -1,0 +1,259 @@
+"""Tests for services/api/src/routes/query.py.
+
+Covers:
+- POST /query: happy path (standard query, mock pipeline)
+- POST /query: cross-union routes to Sonnet
+- POST /query: empty query returns 422
+- POST /query: query_log_id is None when DB write fails (best-effort)
+- POST /query: response structure matches spec
+- POST /query: disclaimer present in response
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.auth import CurrentUser, get_current_user
+from src.config import Settings, get_settings
+from src.main import app
+from src.rag.citation_extractor import CitationRef
+from src.rag.generator import GeneratorResult
+from src.rag.retrieval import ChunkResult
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> None:
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url="postgresql://user:pass@localhost/epsca",
+        qdrant_url="http://localhost:6333",
+        ollama_url="http://localhost:11434",
+        anthropic_api_key="test-key",
+        jwt_secret="test-jwt-secret",  # noqa: S106
+    )
+
+
+@pytest.fixture
+def stub_user() -> CurrentUser:
+    import uuid
+    return CurrentUser(tenant_id=uuid.UUID("00000000-0000-0000-0000-000000000001"))
+
+
+def make_chunk(union_name: str = "IBEW", text: str = "Overtime clause text.") -> ChunkResult:
+    return ChunkResult(
+        point_id="pt-001",
+        score=0.9,
+        document_id="doc-001",
+        source_filename="IBEW_CA.pdf",
+        union_name=union_name,
+        document_type="primary_ca",
+        agreement_scope=None,
+        effective_date="2025-05-01",
+        expiry_date="2030-04-30",
+        article_number="Article 12",
+        article_title="Overtime",
+        section_number="12.03",
+        page_number=34,
+        is_table=False,
+        text=text,
+    )
+
+
+def make_generator_result(answer: str = "Answer [SOURCE 1]", model: str = "claude-haiku-4-5-20251001") -> GeneratorResult:
+    return GeneratorResult(
+        answer=answer,
+        model_used=model,
+        prompt_tokens=100,
+        completion_tokens=50,
+        latency_ms=250,
+    )
+
+
+# ─── Helper: patch full pipeline ──────────────────────────────────────────────
+
+
+def _pipeline_patches(
+    chunks: list[ChunkResult],
+    generator_result: GeneratorResult,
+    known_unions: list[str] | None = None,
+    title_map: dict[str, str] | None = None,
+    log_id: str | None = "aaaaaaaa-0000-0000-0000-000000000001",
+) -> Any:
+    """Context manager providing standard pipeline mocks."""
+    from contextlib import ExitStack
+    import contextlib
+
+    @contextlib.contextmanager  # type: ignore[arg-type]
+    def _stack() -> Any:
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "src.routes.query._get_known_unions",
+                    new=AsyncMock(return_value=known_unions or ["IBEW", "UA"]),
+                )
+            )
+            stack.enter_context(
+                patch("src.routes.query.retrieve", new=AsyncMock(return_value=chunks))
+            )
+            stack.enter_context(
+                patch(
+                    "src.routes.query._get_title_map",
+                    new=AsyncMock(return_value=title_map or {"doc-001": "IBEW CA 2025"}),
+                )
+            )
+            stack.enter_context(
+                patch("src.routes.query.generate", new=AsyncMock(return_value=generator_result))
+            )
+            stack.enter_context(
+                patch(
+                    "src.routes.query._write_query_log",
+                    new=AsyncMock(return_value=log_id),
+                )
+            )
+            yield
+
+    return _stack()
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+def test_query_happy_path(test_settings: Settings, stub_user: CurrentUser) -> None:
+    chunk = make_chunk()
+    gen_result = make_generator_result()
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    with patch("src.main.get_settings", return_value=test_settings):
+        with TestClient(app) as client:
+            with _pipeline_patches([chunk], gen_result):
+                response = client.post("/query", json={"query": "What is overtime pay?"})
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["answer"] == "Answer [SOURCE 1]"
+    assert data["model_used"] == "claude-haiku-4-5-20251001"
+    assert "disclaimer" in data
+    assert "legal advice" in data["disclaimer"]
+    assert data["query_log_id"] == "aaaaaaaa-0000-0000-0000-000000000001"
+
+
+def test_query_response_has_citations(test_settings: Settings, stub_user: CurrentUser) -> None:
+    chunk = make_chunk()
+    gen_result = make_generator_result()
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    with patch("src.main.get_settings", return_value=test_settings):
+        with TestClient(app) as client:
+            with _pipeline_patches([chunk], gen_result):
+                response = client.post("/query", json={"query": "overtime?"})
+
+    app.dependency_overrides.clear()
+
+    data = response.json()
+    assert isinstance(data["citations"], list)
+    assert len(data["citations"]) == 1
+    assert data["citations"][0]["source_number"] == 1
+    assert data["citations"][0]["union_name"] == "IBEW"
+
+
+def test_query_log_id_none_when_db_fails(test_settings: Settings, stub_user: CurrentUser) -> None:
+    chunk = make_chunk()
+    gen_result = make_generator_result()
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    with patch("src.main.get_settings", return_value=test_settings):
+        with TestClient(app) as client:
+            with _pipeline_patches([chunk], gen_result, log_id=None):
+                response = client.post("/query", json={"query": "overtime?"})
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["query_log_id"] is None
+
+
+def test_empty_query_returns_422(test_settings: Settings, stub_user: CurrentUser) -> None:
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    with patch("src.main.get_settings", return_value=test_settings):
+        with TestClient(app) as client:
+            response = client.post("/query", json={"query": "   "})
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 422
+
+
+def test_whitespace_only_query_returns_422(test_settings: Settings, stub_user: CurrentUser) -> None:
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    with patch("src.main.get_settings", return_value=test_settings):
+        with TestClient(app) as client:
+            response = client.post("/query", json={"query": "\t\n"})
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 422
+
+
+def test_cross_union_routes_to_sonnet(test_settings: Settings, stub_user: CurrentUser) -> None:
+    chunk = make_chunk()
+    gen_result = make_generator_result(
+        answer="Compare [SOURCE 1]", model="claude-sonnet-4-6"
+    )
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    mock_generate = AsyncMock(return_value=gen_result)
+
+    with patch("src.main.get_settings", return_value=test_settings):
+        with TestClient(app) as client:
+            with patch("src.routes.query._get_known_unions", new=AsyncMock(return_value=["IBEW"])), \
+                 patch("src.routes.query.retrieve", new=AsyncMock(return_value=[chunk])), \
+                 patch("src.routes.query._get_title_map", new=AsyncMock(return_value={})), \
+                 patch("src.routes.query.generate", new=mock_generate), \
+                 patch("src.routes.query._write_query_log", new=AsyncMock(return_value=None)):
+                response = client.post(
+                    "/query", json={"query": "Compare overtime across all unions"}
+                )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    call_kwargs = mock_generate.call_args.kwargs
+    assert call_kwargs["is_cross_union"] is True
+
+
+def test_missing_query_field_returns_422(test_settings: Settings, stub_user: CurrentUser) -> None:
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    with patch("src.main.get_settings", return_value=test_settings):
+        with TestClient(app) as client:
+            response = client.post("/query", json={})
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 422


### PR DESCRIPTION
Closes #17

## Summary

- `generator.py` — Claude API call with prompt caching (system prompt as cache anchor); routes to Haiku for standard queries and Sonnet for cross-union comparisons
- `citation_extractor.py` — parses `[SOURCE N]` markers from the generated answer into structured `CitationRef` objects mapped back to retrieved chunks
- `auth/__init__.py` — Phase 1 stub `get_current_user` dependency returning `SYSTEM_TENANT_ID`; no JWT enforcement yet
- `routes/query.py` — full RAG pipeline: preprocess → retrieve → context assembly → generate → extract citations → best-effort `query_logs` write → structured response; `QueryRequest` validates max 2000 chars and rejects blank/whitespace queries
- `main.py` — registers query router and `CORSMiddleware`

## Test plan

- [ ] 165/165 tests pass (`pytest -q`)
- [ ] `ruff check src/` clean
- [ ] `mypy src/` strict clean
- [ ] `POST /query` happy path returns answer + citations + disclaimer + `query_log_id`
- [ ] Empty / whitespace query returns 422
- [ ] Cross-union query (`compare`, `all unions`, etc.) calls `generate` with `is_cross_union=True`
- [ ] `query_log_id` is `null` in response when DB write fails (best-effort verified)
- [ ] System prompt contains `cache_control: {type: ephemeral}` on every call

🤖 Generated with [Claude Code](https://claude.com/claude-code)