### PR TITLE
[codex] feat(ingestion): persist wage-table artifact manifest and metadata

### DIFF
--- a/docs/architecture_docling_tpds_wage_ingestion.md
+++ b/docs/architecture_docling_tpds_wage_ingestion.md
@@ -31,12 +31,18 @@ before the legacy `convert.py` → `extract.py` → `chunk.py` sequence.
 
 ## Artifacts And Metadata
 
-Artifacts are written under `services/ingestion/corpus_table_artifacts/<pdf-stem>/`:
+Artifacts are written under `services/ingestion/corpus_table_artifacts/<pdf-stem>--<source-hash>/`:
 
+- `manifest.json`
 - `docling.document.json`
 - `docling.tables.json`
 - `tpds.tables.json`
 - `tpds.chunks.json`
+
+`manifest.json` is the index file for a wage-table run. It records the source
+document id/path, document metadata, row-group settings, artifact file paths,
+table counts, chunk-type counts, and a per-table summary of titles, captions,
+pages, and emitted TPDS chunk counts.
 
 Stored chunk payloads now carry wage-table-specific metadata such as:
 
@@ -48,6 +54,10 @@ Stored chunk payloads now carry wage-table-specific metadata such as:
 - `page_numbers`
 - `row_indexes`
 - `trade_name`
+- `source_document_id`
+- `source_document_filename`
+- `artifact_manifest_path`
+- `raw_docling_document_path`
 - artifact paths for normalized tables and TPDS chunk output
 
 ## First-Pass Limits

--- a/docs/runbooks/ingestion.md
+++ b/docs/runbooks/ingestion.md
@@ -46,10 +46,17 @@ When `INGEST_WAGE_TABLE_PIPELINE=1` is set, manifest entries already marked as
 `document_type: wage_schedule` are routed through:
 
 1. Docling table extraction
-2. raw Docling table artifact capture under `services/ingestion/corpus_table_artifacts/`
+2. artifact capture under `services/ingestion/corpus_table_artifacts/<pdf-stem>--<source-hash>/`
+   including `manifest.json`, `docling.document.json`, `docling.tables.json`,
+   `tpds.tables.json`, and `tpds.chunks.json`
 3. TPDS normalization (`normalizeFromDocling`)
 4. TPDS chunk generation (`buildTableChunks`)
 5. normal embed/store stages using the TPDS-derived chunk text and metadata
+
+The artifact `manifest.json` is the first place to inspect when a wage-table
+run looks wrong. It indexes the artifact files and records the source document
+id/path, manifest metadata, row-group setting, table counts, and TPDS chunk
+counts by type.
 
 If that branch fails and `INGEST_WAGE_TABLE_FALLBACK` is not set to `0`, the
 pipeline falls back to the existing Markdown/pdfplumber path.

--- a/services/ingestion/tests/test_store.py
+++ b/services/ingestion/tests/test_store.py
@@ -212,7 +212,9 @@ class TestStoreDocumentPostgres:
         assert "IBEW" in all_args
 
     @pytest.mark.asyncio
-    async def test_qdrant_payload_includes_chunk_metadata(self, tmp_path: Path) -> None:
+    async def test_qdrant_payload_includes_wage_table_retrieval_metadata(
+        self, tmp_path: Path
+    ) -> None:
         doc = _make_doc(tmp_path)
         chunks = [
             Chunk(
@@ -224,10 +226,24 @@ class TestStoreDocumentPostgres:
                 article_title="IBEW Generation Wage Schedule",
                 chunk_index=0,
                 metadata={
+                    "document_title": doc.metadata.title,
+                    "trade_name": "IBEW Generation",
                     "table_pipeline": "docling_tpds",
+                    "table_chunk_type": "row",
                     "table_id": "table-1",
+                    "table_title": "IBEW Generation Wage Schedule",
+                    "table_caption": "IBEW Generation Wage Schedule",
+                    "page_numbers": [1],
                     "row_indexes": [1],
+                    "source_document_id": "doc-1",
+                    "source_document_filename": doc.extracted.source_path.name,
+                    "source_document_path": doc.extracted.source_path,
+                    "artifact_manifest_path": tmp_path / "manifest.json",
+                    "table_artifact_dir": tmp_path / "artifacts",
+                    "raw_docling_document_path": tmp_path / "docling.document.json",
+                    "raw_docling_tables_path": tmp_path / "docling.tables.json",
                     "normalized_table_json_path": tmp_path / "tables.json",
+                    "tpds_chunk_manifest_path": tmp_path / "tpds.chunks.json",
                 },
             )
         ]
@@ -245,11 +261,27 @@ class TestStoreDocumentPostgres:
         points = qdrant.upsert.call_args.kwargs["points"]
         payload = points[0].payload
         assert payload["title"] == doc.metadata.title
+        assert payload["effective_date"] == doc.metadata.effective_date
+        assert payload["union_name"] == doc.metadata.union_name
+        assert payload["document_title"] == doc.metadata.title
+        assert payload["trade_name"] == "IBEW Generation"
         assert payload["source_path"] == str(doc.extracted.source_path)
+        assert payload["source_document_path"] == str(doc.extracted.source_path)
+        assert payload["source_document_filename"] == doc.extracted.source_path.name
+        assert payload["source_document_id"] == "doc-1"
         assert payload["table_pipeline"] == "docling_tpds"
+        assert payload["table_chunk_type"] == "row"
         assert payload["table_id"] == "table-1"
+        assert payload["table_title"] == "IBEW Generation Wage Schedule"
+        assert payload["table_caption"] == "IBEW Generation Wage Schedule"
+        assert payload["page_numbers"] == [1]
         assert payload["row_indexes"] == [1]
+        assert payload["artifact_manifest_path"] == str(tmp_path / "manifest.json")
+        assert payload["table_artifact_dir"] == str(tmp_path / "artifacts")
+        assert payload["raw_docling_document_path"] == str(tmp_path / "docling.document.json")
+        assert payload["raw_docling_tables_path"] == str(tmp_path / "docling.tables.json")
         assert payload["normalized_table_json_path"] == str(tmp_path / "tables.json")
+        assert payload["tpds_chunk_manifest_path"] == str(tmp_path / "tpds.chunks.json")
 
     @pytest.mark.asyncio
     async def test_postgres_receives_chunk_count(self, tmp_path: Path) -> None:

--- a/services/ingestion/tests/test_wage_tables.py
+++ b/services/ingestion/tests/test_wage_tables.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from wage_tables import (
     WageTableConfig,
+    _prepare_artifact_paths,
     process_wage_schedule_pdf,
     should_use_wage_table_pipeline,
 )
@@ -140,18 +141,66 @@ def test_process_wage_schedule_pdf_writes_artifacts_and_tpds_chunks(tmp_path: Pa
     assert row_chunk.metadata["row_indexes"] == [1]
     assert row_chunk.metadata["page_numbers"] == [1]
     assert row_chunk.metadata["trade_name"] == "IBEW Generation"
+    assert row_chunk.metadata["source_document_path"] == str(pdf_path)
+    assert row_chunk.metadata["source_document_filename"] == pdf_path.name
     assert row_chunk.metadata["wage_schedule"] is True
     assert "Journeyperson" in row_chunk.text
     assert "$44.96" in row_chunk.text
 
+    manifest = json.loads(result.artifacts.manifest_path.read_text(encoding="utf-8"))
     raw_tables = json.loads(result.artifacts.raw_tables_path.read_text(encoding="utf-8"))
     normalized = json.loads(result.artifacts.normalized_tables_path.read_text(encoding="utf-8"))
     chunk_manifest = json.loads(result.artifacts.chunk_manifest_path.read_text(encoding="utf-8"))
 
+    assert result.artifacts.artifact_dir.name.startswith(
+        "E-1-C LU 773 Windsor - May 1, 2025--"
+    )
+    assert result.artifacts.manifest_path.exists()
     assert result.artifacts.raw_docling_path.exists()
     assert result.artifacts.raw_tables_path.exists()
     assert result.artifacts.normalized_tables_path.exists()
     assert result.artifacts.chunk_manifest_path.exists()
+    assert manifest["schema_version"] == 1
+    assert manifest["pipeline"] == "docling_tpds"
+    assert manifest["source_document"]["path"] == str(pdf_path)
+    assert manifest["source_document"]["filename"] == pdf_path.name
+    assert manifest["source_document"]["title"] == result.classified.metadata.title
+    assert manifest["source_document"]["trade_name"] == "IBEW Generation"
+    assert manifest["counts"]["page_count"] == 1
+    assert manifest["counts"]["docling_table_count"] == 1
+    assert manifest["counts"]["tpds_table_count"] == 1
+    assert manifest["counts"]["tpds_chunk_count"] == 3
+    assert manifest["counts"]["chunk_types"] == {"summary": 1, "row": 1, "row-group": 1}
+    assert manifest["artifacts"]["manifest_path"] == str(result.artifacts.manifest_path)
+    assert manifest["tables"] == [
+        {
+            "table_id": "E-1-C LU 773 Windsor - May 1, 2025-table-1",
+            "title": "IBEW Generation Wage Schedule",
+            "caption": "IBEW Generation Wage Schedule",
+            "pages": [1],
+            "chunk_count": 3,
+            "chunk_types": {"summary": 1, "row": 1, "row-group": 1},
+        }
+    ]
     assert len(raw_tables) == 1
     assert normalized[0]["tableId"] == "E-1-C LU 773 Windsor - May 1, 2025-table-1"
     assert chunk_manifest[1]["chunkType"] == "row"
+
+
+def test_prepare_artifact_paths_namespaces_same_filename_paths(tmp_path: Path) -> None:
+    config = WageTableConfig(
+        enabled=True,
+        fallback_enabled=True,
+        artifact_dir=tmp_path / "artifacts",
+        row_group_size=3,
+    )
+
+    first_pdf = tmp_path / "set-a" / "wage.pdf"
+    second_pdf = tmp_path / "set-b" / "wage.pdf"
+
+    first_artifacts = _prepare_artifact_paths(first_pdf, config)
+    second_artifacts = _prepare_artifact_paths(second_pdf, config)
+
+    assert first_artifacts.artifact_dir != second_artifacts.artifact_dir
+    assert first_artifacts.artifact_dir.name.startswith("wage--")
+    assert second_artifacts.artifact_dir.name.startswith("wage--")

--- a/services/ingestion/wage_tables.py
+++ b/services/ingestion/wage_tables.py
@@ -7,6 +7,7 @@ import logging
 import os
 import shutil
 import subprocess
+import uuid
 from chunk import Chunk
 from dataclasses import dataclass
 from pathlib import Path
@@ -53,6 +54,7 @@ class WageTableConfig:
 @dataclass(frozen=True)
 class WageTableArtifacts:
     artifact_dir: Path
+    manifest_path: Path
     raw_docling_path: Path
     raw_tables_path: Path
     normalized_tables_path: Path
@@ -110,10 +112,27 @@ def _extract_docling_document(pdf_path: Path) -> dict[str, Any]:
     return exported
 
 
+def _source_document_key(pdf_path: Path) -> str:
+    try:
+        return str(pdf_path.resolve().relative_to(_HERE.resolve()))
+    except ValueError:
+        return str(pdf_path.resolve())
+
+
+def _source_document_id(pdf_path: Path) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, _source_document_key(pdf_path)))
+
+
+def _artifact_dir_name(pdf_path: Path) -> str:
+    source_digest = _source_document_id(pdf_path).replace("-", "")[:12]
+    return f"{pdf_path.stem}--{source_digest}"
+
+
 def _prepare_artifact_paths(pdf_path: Path, config: WageTableConfig) -> WageTableArtifacts:
-    artifact_dir = config.artifact_dir / pdf_path.stem
+    artifact_dir = config.artifact_dir / _artifact_dir_name(pdf_path)
     return WageTableArtifacts(
         artifact_dir=artifact_dir,
+        manifest_path=artifact_dir / "manifest.json",
         raw_docling_path=artifact_dir / "docling.document.json",
         raw_tables_path=artifact_dir / "docling.tables.json",
         normalized_tables_path=artifact_dir / "tpds.tables.json",
@@ -149,7 +168,7 @@ def _run_tpds_bridge(
                     "tableId": f"{pdf_path.stem}-table-{index + 1}",
                     "title": _table_title(table_item, doc.metadata.title, index),
                     "caption": table_item.get("caption"),
-                    "sourceDocumentId": str(pdf_path),
+                    "sourceDocumentId": _source_document_id(pdf_path),
                 },
             }
             for index, table_item in enumerate(raw_tables)
@@ -202,6 +221,129 @@ def _derive_trade_name(doc: ClassifiedDocument) -> str:
     return doc.metadata.union_name
 
 
+def _normalize_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _normalize_int_list(value: object) -> list[int]:
+    if not isinstance(value, list):
+        return []
+
+    normalized: list[int] = []
+    for item in value:
+        if isinstance(item, int) and item not in normalized:
+            normalized.append(item)
+    return normalized
+
+
+def _normalize_str_list(value: object) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+
+    normalized = [item.strip() for item in value if isinstance(item, str) and item.strip()]
+    return normalized or None
+
+
+def _chunk_type_counts(chunks: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for chunk in chunks:
+        if not isinstance(chunk, dict):
+            continue
+        chunk_type = _normalize_text(chunk.get("chunkType")) or "unknown"
+        counts[chunk_type] = counts.get(chunk_type, 0) + 1
+    return counts
+
+
+def _table_manifest_entries(
+    normalized_tables: list[dict[str, Any]],
+    table_chunks: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    chunk_counts_by_table: dict[str, dict[str, int]] = {}
+    for table_chunk in table_chunks:
+        if not isinstance(table_chunk, dict):
+            continue
+
+        table_id = _normalize_text(table_chunk.get("tableId"))
+        if not table_id:
+            continue
+
+        table_counts = chunk_counts_by_table.setdefault(table_id, {})
+        chunk_type = _normalize_text(table_chunk.get("chunkType")) or "unknown"
+        table_counts[chunk_type] = table_counts.get(chunk_type, 0) + 1
+
+    table_entries: list[dict[str, Any]] = []
+    for index, normalized_table in enumerate(normalized_tables):
+        if not isinstance(normalized_table, dict):
+            continue
+
+        table_id = _normalize_text(normalized_table.get("tableId")) or f"table-{index + 1}"
+        table_chunk_counts = chunk_counts_by_table.get(table_id, {})
+        table_entries.append(
+            {
+                "table_id": table_id,
+                "title": _normalize_text(normalized_table.get("title")),
+                "caption": _normalize_text(normalized_table.get("caption")),
+                "pages": _normalize_int_list(normalized_table.get("pages")),
+                "chunk_count": sum(table_chunk_counts.values()),
+                "chunk_types": table_chunk_counts,
+            }
+        )
+
+    return table_entries
+
+
+def _build_artifact_manifest(
+    doc: ClassifiedDocument,
+    pdf_path: Path,
+    config: WageTableConfig,
+    artifacts: WageTableArtifacts,
+    page_count: int,
+    raw_tables: list[dict[str, Any]],
+    normalized_tables: list[dict[str, Any]],
+    table_chunks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "pipeline": "docling_tpds",
+        "source_document": {
+            "id": _source_document_id(pdf_path),
+            "key": _source_document_key(pdf_path),
+            "path": str(pdf_path),
+            "filename": pdf_path.name,
+            "title": doc.metadata.title,
+            "union_name": doc.metadata.union_name,
+            "trade_name": _derive_trade_name(doc),
+            "document_type": doc.metadata.document_type,
+            "agreement_scope": doc.metadata.agreement_scope,
+            "effective_date": doc.metadata.effective_date,
+            "expiry_date": doc.metadata.expiry_date,
+            "source_url": doc.metadata.source_url,
+        },
+        "settings": {
+            "row_group_size": config.row_group_size,
+        },
+        "counts": {
+            "page_count": page_count,
+            "docling_table_count": len(raw_tables),
+            "tpds_table_count": len(normalized_tables),
+            "tpds_chunk_count": len(table_chunks),
+            "chunk_types": _chunk_type_counts(table_chunks),
+        },
+        "artifacts": {
+            "artifact_dir": str(artifacts.artifact_dir),
+            "manifest_path": str(artifacts.manifest_path),
+            "raw_docling_path": str(artifacts.raw_docling_path),
+            "raw_tables_path": str(artifacts.raw_tables_path),
+            "normalized_tables_path": str(artifacts.normalized_tables_path),
+            "chunk_manifest_path": str(artifacts.chunk_manifest_path),
+        },
+        "tables": _table_manifest_entries(normalized_tables, table_chunks),
+    }
+
+
 def _tpds_chunks_to_ingestion_chunks(
     doc: ClassifiedDocument,
     pdf_path: Path,
@@ -209,51 +351,41 @@ def _tpds_chunks_to_ingestion_chunks(
     tpds_chunks: list[dict[str, Any]],
 ) -> list[Chunk]:
     trade_name = _derive_trade_name(doc)
+    source_document_id = _source_document_id(pdf_path)
     chunks: list[Chunk] = []
 
     for index, table_chunk in enumerate(tpds_chunks):
         if not isinstance(table_chunk, dict):
             continue
 
-        page_numbers = table_chunk.get("pages")
-        normalized_pages = (
-            [int(page) for page in page_numbers if isinstance(page, int)]
-            if isinstance(page_numbers, list)
-            else []
-        )
+        normalized_pages = _normalize_int_list(table_chunk.get("pages"))
         page_number = normalized_pages[0] if normalized_pages else 1
 
-        row_indexes = table_chunk.get("rowIndexes")
-        normalized_rows = (
-            [int(row) for row in row_indexes if isinstance(row, int)]
-            if isinstance(row_indexes, list)
-            else []
-        )
+        normalized_rows = _normalize_int_list(table_chunk.get("rowIndexes"))
+        normalized_section_path = _normalize_str_list(table_chunk.get("sectionPath"))
 
-        section_path = table_chunk.get("sectionPath")
-        normalized_section_path = (
-            [str(part) for part in section_path]
-            if isinstance(section_path, list)
-            else None
-        )
-
-        table_title = table_chunk.get("title")
-        title_text = str(table_title) if isinstance(table_title, str) else None
-        caption = table_chunk.get("caption")
-        caption_text = str(caption) if isinstance(caption, str) else None
+        title_text = _normalize_text(table_chunk.get("title"))
+        caption_text = _normalize_text(table_chunk.get("caption"))
+        table_id = _normalize_text(table_chunk.get("tableId"))
+        chunk_type = _normalize_text(table_chunk.get("chunkType"))
 
         metadata: dict[str, object] = {
             "document_title": doc.metadata.title,
             "trade_name": trade_name,
             "table_pipeline": "docling_tpds",
-            "table_chunk_type": str(table_chunk.get("chunkType", "")),
-            "table_id": str(table_chunk.get("tableId", "")),
+            "table_chunk_type": chunk_type,
+            "table_id": table_id,
             "table_title": title_text or doc.metadata.title,
             "table_caption": caption_text,
             "page_numbers": normalized_pages,
             "row_indexes": normalized_rows,
             "section_path": normalized_section_path,
+            "source_document_id": source_document_id,
             "source_document_path": str(pdf_path),
+            "source_document_filename": pdf_path.name,
+            "artifact_manifest_path": str(artifacts.manifest_path),
+            "table_artifact_dir": str(artifacts.artifact_dir),
+            "raw_docling_document_path": str(artifacts.raw_docling_path),
             "raw_docling_tables_path": str(artifacts.raw_tables_path),
             "normalized_table_json_path": str(artifacts.normalized_tables_path),
             "tpds_chunk_manifest_path": str(artifacts.chunk_manifest_path),
@@ -298,11 +430,22 @@ def process_wage_schedule_pdf(
     )
 
     normalized_tables, table_chunks = _run_tpds_bridge(raw_tables, classified, pdf_path, config)
+    artifact_manifest = _build_artifact_manifest(
+        classified,
+        pdf_path,
+        config,
+        artifacts,
+        page_count,
+        raw_tables,
+        normalized_tables,
+        table_chunks,
+    )
 
     _write_json(artifacts.raw_docling_path, docling_export)
     _write_json(artifacts.raw_tables_path, raw_tables)
     _write_json(artifacts.normalized_tables_path, normalized_tables)
     _write_json(artifacts.chunk_manifest_path, table_chunks)
+    _write_json(artifacts.manifest_path, artifact_manifest)
 
     chunks = _tpds_chunks_to_ingestion_chunks(classified, pdf_path, artifacts, table_chunks)
     logger.info(


### PR DESCRIPTION
## Summary
- add a wage-table artifact manifest that indexes Docling and TPDS outputs for each ingestion run
- namespace wage-table artifact directories by source document so same-named PDFs do not collide
- normalize and expand retrieval metadata for TPDS-derived wage-table chunks

## Why
Issue #62 closed the parent Docling + TPDS ingestion path for #58, but issue #61 was still thin in two areas:
- artifact persistence was just a loose set of JSON files under a stem-only directory
- tests did not verify the full retrieval metadata needed to debug or inspect wage-table retrieval later

This follow-up makes the artifact output more intentional and ensures the wage-table metadata that reaches Qdrant is explicit and reviewable.

Closes #61.

## What Changed
- added `manifest.json` alongside `docling.document.json`, `docling.tables.json`, `tpds.tables.json`, and `tpds.chunks.json`
- changed artifact directory naming to `corpus_table_artifacts/<pdf-stem>--<source-hash>/`
- recorded source document ids, artifact paths, counts, and per-table summaries in the artifact manifest
- added `source_document_id`, `source_document_filename`, `artifact_manifest_path`, `table_artifact_dir`, and `raw_docling_document_path` to wage-table chunk metadata
- expanded ingestion tests to verify artifact manifests, namespaced artifact paths, and stored retrieval metadata
- updated the Docling + TPDS architecture note and ingestion runbook

## Validation
- `ruff check .` in `services/ingestion`
- `python3 -m pytest services/ingestion/tests`

## Scope Notes
- leaves non-wage ingestion behavior unchanged
- does not attempt the multi-page and repeated-header work tracked in #60
- does not rerun corpus ingestion or Phase 1 evaluation, which stays in #59
