### PR TITLE
[codex] fix(ingestion): handle multi-page wage tables in Docling + TPDS path

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,8 +45,19 @@ jobs:
           cache: "pip"
           cache-dependency-path: services/ingestion/requirements.txt
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: services/ingestion/package-lock.json
+
       - name: Install dependencies
         run: pip install -r services/ingestion/requirements.txt
+
+      - name: Install Node dependencies
+        working-directory: services/ingestion
+        run: npm ci
 
       - name: Lint
         working-directory: services/ingestion

--- a/docs/architecture_docling_tpds_wage_ingestion.md
+++ b/docs/architecture_docling_tpds_wage_ingestion.md
@@ -15,9 +15,12 @@ before the legacy `convert.py` → `extract.py` → `chunk.py` sequence.
 2. Run Docling against the PDF and capture:
    - full Docling document JSON
    - raw Docling table JSON
-3. Send each Docling table to the TPDS bridge (`tpds_bridge.mjs`), which calls:
-   - `normalizeFromDocling`
-   - `buildTableChunks`
+3. Send Docling tables to the TPDS bridge (`tpds_bridge.mjs`), which:
+   - calls `normalizeFromDocling`
+   - groups adjacent page fragments for the same logical wage table
+   - marks repeated continuation headers before merge when Docling emits them as rows
+   - merges logical multi-page tables
+   - rebuilds TPDS row and row-group chunks from the merged table
 4. Persist TPDS normalized tables and chunk manifests as local artifacts.
 5. Convert TPDS chunks into the existing ingestion `Chunk` model with extra metadata.
 6. Reuse the existing `embed.py` and `store.py` stages unchanged apart from payload enrichment.
@@ -60,8 +63,7 @@ Stored chunk payloads now carry wage-table-specific metadata such as:
 - `raw_docling_document_path`
 - artifact paths for normalized tables and TPDS chunk output
 
-## First-Pass Limits
+## Current Limits
 
-- Multi-page logical table merging is not implemented yet.
-- Repeated continuation headers depend on Docling output quality and still need real-PDF validation.
-- Merged-cell and grouped-header preservation needs broader EPSCA corpus verification, especially for wide schedules.
+- Grouped-header and merged-cell preservation now has fixture coverage, but it still needs broader EPSCA corpus verification on wide schedules and less regular layouts.
+- Summary chunks still inherit TPDS's generic column labels when Docling does not expose enough column-label metadata directly.

--- a/docs/runbooks/ingestion.md
+++ b/docs/runbooks/ingestion.md
@@ -50,13 +50,16 @@ When `INGEST_WAGE_TABLE_PIPELINE=1` is set, manifest entries already marked as
    including `manifest.json`, `docling.document.json`, `docling.tables.json`,
    `tpds.tables.json`, and `tpds.chunks.json`
 3. TPDS normalization (`normalizeFromDocling`)
-4. TPDS chunk generation (`buildTableChunks`)
-5. normal embed/store stages using the TPDS-derived chunk text and metadata
+4. TPDS logical-table merge and continuation-header cleanup for adjacent multi-page wage-table fragments
+5. TPDS chunk generation (`buildTableChunks`) from the merged table
+6. normal embed/store stages using the TPDS-derived chunk text and metadata
 
 The artifact `manifest.json` is the first place to inspect when a wage-table
 run looks wrong. It indexes the artifact files and records the source document
 id/path, manifest metadata, row-group setting, table counts, and TPDS chunk
-counts by type.
+counts by type. For `#60`-style continuation issues, inspect `tpds.tables.json`
+for merged `pages`, `continuity`, and `repeatedHeaderRow` markers before
+looking at the emitted row and row-group chunks.
 
 If that branch fails and `INGEST_WAGE_TABLE_FALLBACK` is not set to `0`, the
 pipeline falls back to the existing Markdown/pdfplumber path.

--- a/services/ingestion/tests/fixtures/epsca_wage_schedule_docling_grouped_headers.json
+++ b/services/ingestion/tests/fixtures/epsca_wage_schedule_docling_grouped_headers.json
@@ -1,0 +1,106 @@
+{
+  "pages": {
+    "1": {
+      "page_no": 1
+    }
+  },
+  "tables": [
+    {
+      "caption": "IBEW Generation Wage Schedule",
+      "prov": [
+        {
+          "page_no": 1
+        }
+      ],
+      "data": {
+        "num_cols": 4,
+        "grid": [
+          [
+            {
+              "text": "Classification",
+              "column_header": true,
+              "row_span": 2,
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "Base Rates",
+              "column_header": true,
+              "col_span": 2,
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 1
+            },
+            null,
+            {
+              "text": "Effective Date",
+              "column_header": true,
+              "row_span": 2,
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 3
+            }
+          ],
+          [
+            null,
+            {
+              "text": "Day Shift",
+              "column_header": true,
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "Night Shift",
+              "column_header": true,
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 2
+            },
+            null
+          ],
+          [
+            {
+              "text": "Journeyperson",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "$44.96",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "$46.96",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 2
+            },
+            {
+              "text": "2025-05-01",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 3
+            }
+          ],
+          [
+            {
+              "text": "Foreperson",
+              "start_row_offset_idx": 3,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "$50.35",
+              "start_row_offset_idx": 3,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "$52.35",
+              "start_row_offset_idx": 3,
+              "start_col_offset_idx": 2
+            },
+            {
+              "text": "2025-05-01",
+              "start_row_offset_idx": 3,
+              "start_col_offset_idx": 3
+            }
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/services/ingestion/tests/fixtures/epsca_wage_schedule_docling_multipage.json
+++ b/services/ingestion/tests/fixtures/epsca_wage_schedule_docling_multipage.json
@@ -1,0 +1,174 @@
+{
+  "pages": {
+    "1": {
+      "page_no": 1
+    },
+    "2": {
+      "page_no": 2
+    }
+  },
+  "tables": [
+    {
+      "caption": "IBEW Generation Wage Schedule",
+      "prov": [
+        {
+          "page_no": 1
+        }
+      ],
+      "data": {
+        "num_cols": 4,
+        "grid": [
+          [
+            {
+              "text": "Classification",
+              "column_header": true,
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "Base Rate",
+              "column_header": true,
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "Foreperson Differential",
+              "column_header": true,
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 2
+            },
+            {
+              "text": "Effective Date",
+              "column_header": true,
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 3
+            }
+          ],
+          [
+            {
+              "text": "Journeyperson",
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "$44.96",
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "12%",
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 2
+            },
+            {
+              "text": "2025-05-01",
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 3
+            }
+          ],
+          [
+            {
+              "text": "Foreperson",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "$50.35",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "15%",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 2
+            },
+            {
+              "text": "2025-05-01",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 3
+            }
+          ]
+        ]
+      }
+    },
+    {
+      "caption": "IBEW Generation Wage Schedule",
+      "prov": [
+        {
+          "page_no": 2
+        }
+      ],
+      "data": {
+        "num_cols": 4,
+        "grid": [
+          [
+            {
+              "text": "Classification",
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "Base Rate",
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "Foreperson Differential",
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 2
+            },
+            {
+              "text": "Effective Date",
+              "start_row_offset_idx": 0,
+              "start_col_offset_idx": 3
+            }
+          ],
+          [
+            {
+              "text": "Apprentice 1st Term",
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "$33.72",
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "0%",
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 2
+            },
+            {
+              "text": "2025-05-01",
+              "start_row_offset_idx": 1,
+              "start_col_offset_idx": 3
+            }
+          ],
+          [
+            {
+              "text": "General Foreperson",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 0
+            },
+            {
+              "text": "$58.55",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 1
+            },
+            {
+              "text": "20%",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 2
+            },
+            {
+              "text": "2025-05-01",
+              "start_row_offset_idx": 2,
+              "start_col_offset_idx": 3
+            }
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/services/ingestion/tests/test_wage_tables.py
+++ b/services/ingestion/tests/test_wage_tables.py
@@ -3,22 +3,57 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+from classify import ClassifiedDocument, DocumentMetadata
+from extract import ExtractedDocument
 from wage_tables import (
     WageTableConfig,
     _prepare_artifact_paths,
+    _run_tpds_bridge,
     process_wage_schedule_pdf,
     should_use_wage_table_pipeline,
 )
 
 _FIXTURE_DIR = Path(__file__).parent / "fixtures"
 _FIXTURE_PATH = _FIXTURE_DIR / "epsca_wage_schedule_docling.json"
+_MULTI_PAGE_FIXTURE_PATH = _FIXTURE_DIR / "epsca_wage_schedule_docling_multipage.json"
+_GROUPED_HEADER_FIXTURE_PATH = _FIXTURE_DIR / "epsca_wage_schedule_docling_grouped_headers.json"
+
+
+def _load_json_fixture(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _load_docling_fixture() -> dict[str, object]:
-    return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    return _load_json_fixture(_FIXTURE_PATH)
+
+
+def _load_multi_page_docling_fixture() -> dict[str, object]:
+    return _load_json_fixture(_MULTI_PAGE_FIXTURE_PATH)
+
+
+def _load_grouped_header_docling_fixture() -> dict[str, object]:
+    return _load_json_fixture(_GROUPED_HEADER_FIXTURE_PATH)
+
+
+def _classified_wage_doc(pdf_path: Path, title: str) -> ClassifiedDocument:
+    return ClassifiedDocument(
+        extracted=ExtractedDocument(source_path=pdf_path, blocks=[], page_count=1),
+        metadata=DocumentMetadata(
+            union_name="IBEW",
+            document_type="wage_schedule",
+            agreement_scope="generation",
+            effective_date="2025-05-01",
+            expiry_date=None,
+            title=title,
+            source_url=None,
+        ),
+    )
 
 
 def test_should_route_only_when_enabled() -> None:
@@ -204,3 +239,111 @@ def test_prepare_artifact_paths_namespaces_same_filename_paths(tmp_path: Path) -
     assert first_artifacts.artifact_dir != second_artifacts.artifact_dir
     assert first_artifacts.artifact_dir.name.startswith("wage--")
     assert second_artifacts.artifact_dir.name.startswith("wage--")
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js required for TPDS bridge")
+def test_process_wage_schedule_pdf_merges_multi_page_tables_and_suppresses_repeated_headers(
+    tmp_path: Path,
+) -> None:
+    pdf_path = tmp_path / "E-1-C LU 773 Windsor - May 1, 2025.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake pdf")
+
+    config = WageTableConfig(
+        enabled=True,
+        fallback_enabled=True,
+        artifact_dir=tmp_path / "artifacts",
+        row_group_size=2,
+    )
+
+    with patch(
+        "wage_tables._extract_docling_document",
+        return_value=_load_multi_page_docling_fixture(),
+    ):
+        result = process_wage_schedule_pdf(pdf_path, config)
+
+    assert result.page_count == 2
+    assert result.table_count == 2
+    assert len(result.chunks) == 7
+
+    row_chunks = [
+        chunk for chunk in result.chunks if chunk.metadata["table_chunk_type"] == "row"
+    ]
+    row_group_chunks = [
+        chunk for chunk in result.chunks if chunk.metadata["table_chunk_type"] == "row-group"
+    ]
+
+    assert len(row_chunks) == 4
+    assert len(row_group_chunks) == 2
+    assert all("Classification: Classification" not in chunk.text for chunk in result.chunks)
+    assert all("Base Rate: Base Rate" not in chunk.text for chunk in result.chunks)
+    assert any("Apprentice 1st Term" in chunk.text for chunk in row_chunks)
+    assert any("General Foreperson" in chunk.text for chunk in row_chunks)
+
+    normalized = json.loads(result.artifacts.normalized_tables_path.read_text(encoding="utf-8"))
+    manifest = json.loads(result.artifacts.manifest_path.read_text(encoding="utf-8"))
+
+    assert len(normalized) == 1
+    assert normalized[0]["pages"] == [1, 2]
+    assert normalized[0]["continuity"]["isMultiPage"] is True
+    assert "multi-page-merged" in normalized[0]["fidelityWarnings"]
+    repeated_rows = [row for row in normalized[0]["rows"] if row.get("repeatedHeaderRow")]
+    assert len(repeated_rows) == 1
+    assert repeated_rows[0]["page"] == 2
+
+    assert manifest["counts"]["docling_table_count"] == 2
+    assert manifest["counts"]["tpds_table_count"] == 1
+    assert manifest["counts"]["tpds_chunk_count"] == 7
+    assert manifest["counts"]["chunk_types"] == {"summary": 1, "row": 4, "row-group": 2}
+    assert manifest["tables"] == [
+        {
+            "table_id": "E-1-C LU 773 Windsor - May 1, 2025-table-1",
+            "title": "IBEW Generation Wage Schedule",
+            "caption": "IBEW Generation Wage Schedule",
+            "pages": [1, 2],
+            "chunk_count": 7,
+            "chunk_types": {"summary": 1, "row": 4, "row-group": 2},
+        }
+    ]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js required for TPDS bridge")
+def test_run_tpds_bridge_preserves_grouped_headers_and_merged_cells(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "E-1-C LU 773 Windsor - May 1, 2025.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake pdf")
+
+    config = WageTableConfig(
+        enabled=True,
+        fallback_enabled=True,
+        artifact_dir=tmp_path / "artifacts",
+        row_group_size=2,
+    )
+
+    raw_tables = _load_grouped_header_docling_fixture()["tables"]
+    assert isinstance(raw_tables, list)
+
+    normalized_tables, table_chunks = _run_tpds_bridge(
+        raw_tables,
+        _classified_wage_doc(pdf_path, "IBEW Generation Wage Schedule E-1-C LU 773 Windsor"),
+        pdf_path,
+        config,
+    )
+
+    assert len(normalized_tables) == 1
+    assert len(table_chunks) == 4
+
+    normalized_table = normalized_tables[0]
+    merged_header = next(
+        cell for cell in normalized_table["cells"] if cell["textNormalized"] == "Base Rates"
+    )
+    stacked_header = next(
+        cell for cell in normalized_table["cells"] if cell["textNormalized"] == "Classification"
+    )
+
+    assert merged_header["colSpan"] == 2
+    assert stacked_header["rowSpan"] == 2
+
+    row_chunks = [chunk for chunk in table_chunks if chunk["chunkType"] == "row"]
+    assert len(row_chunks) == 2
+    assert "Base Rates > Day Shift: $44.96" in row_chunks[0]["text"]
+    assert "Base Rates > Night Shift: $46.96" in row_chunks[0]["text"]
+    assert "Effective Date: 2025-05-01" in row_chunks[0]["text"]

--- a/services/ingestion/tpds_bridge.mjs
+++ b/services/ingestion/tpds_bridge.mjs
@@ -2,8 +2,13 @@ import process from "node:process";
 
 import {
   buildTableChunks,
+  inferHeaders,
+  mergeMultiPageTables,
   normalizeFromDocling,
 } from "table-preserving-doc-standard";
+
+const AUTO_TABLE_SUFFIX_RE = /\s+[—-]\s+Table\s+\d+$/iu;
+const MAX_LEADING_ROWS = 4;
 
 async function readStdin() {
   const chunks = [];
@@ -16,6 +21,220 @@ async function readStdin() {
 function fail(message) {
   process.stderr.write(`${message}\n`);
   process.exit(1);
+}
+
+function normalizeText(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim().replace(/\s+/gu, " ");
+}
+
+function stripAutoTableSuffix(value) {
+  return normalizeText(value).replace(AUTO_TABLE_SUFFIX_RE, "");
+}
+
+function cellsForRow(table, row) {
+  const cellMap = new Map(table.cells.map((cell) => [cell.cellId, cell]));
+  return row.cellIds
+    .map((cellId) => cellMap.get(cellId))
+    .filter((cell) => Boolean(cell))
+    .sort((left, right) => left.colIndex - right.colIndex);
+}
+
+function sortRows(rows) {
+  return [...rows].sort((left, right) => left.rowIndex - right.rowIndex);
+}
+
+function rowSignature(table, row) {
+  const parts = cellsForRow(table, row)
+    .map((cell) => {
+      const text = normalizeText(cell.textNormalized || cell.textRaw || "");
+      if (!text) {
+        return null;
+      }
+      const rowSpan = cell.rowSpan ?? 1;
+      const colSpan = cell.colSpan ?? 1;
+      return `${cell.colIndex}:${text}:${rowSpan}:${colSpan}`;
+    })
+    .filter((part) => Boolean(part));
+  return parts.join("|");
+}
+
+function headerRowSignatures(table) {
+  return sortRows(table.rows)
+    .filter((row) => row.rowType === "header")
+    .map((row) => rowSignature(table, row))
+    .filter((signature) => Boolean(signature));
+}
+
+function appendWarnings(table, warnings) {
+  const nextWarnings = new Set(table.fidelityWarnings ?? []);
+  for (const warning of warnings) {
+    if (warning) {
+      nextWarnings.add(warning);
+    }
+  }
+  return nextWarnings.size > 0 ? [...nextWarnings] : undefined;
+}
+
+function firstPage(table) {
+  return table.pages.reduce((minimum, page) => Math.min(minimum, page), Number.POSITIVE_INFINITY);
+}
+
+function lastPage(table) {
+  return table.pages.reduce((maximum, page) => Math.max(maximum, page), Number.NEGATIVE_INFINITY);
+}
+
+function tableTitleKey(table) {
+  return normalizeText(table.caption) || stripAutoTableSuffix(table.title);
+}
+
+function sameSourceDocument(left, right) {
+  return normalizeText(left.sourceDocumentId) === normalizeText(right.sourceDocumentId);
+}
+
+function areAdjacentFragments(left, right) {
+  const previousLastPage = lastPage(left);
+  const nextFirstPage = firstPage(right);
+  return (
+    Number.isFinite(previousLastPage) &&
+    Number.isFinite(nextFirstPage) &&
+    nextFirstPage === previousLastPage + 1
+  );
+}
+
+function hasCompatibleHeaders(groupHeaderSignatures, table) {
+  const currentHeaderSignatures = headerRowSignatures(table);
+  if (groupHeaderSignatures.length === 0 || currentHeaderSignatures.length === 0) {
+    return true;
+  }
+  const shared = currentHeaderSignatures.filter((signature) =>
+    groupHeaderSignatures.includes(signature)
+  );
+  return shared.length > 0;
+}
+
+function shouldMergeIntoGroup(group, table) {
+  return (
+    sameSourceDocument(group.anchorTable, table) &&
+    areAdjacentFragments(group.lastTable, table) &&
+    tableTitleKey(group.anchorTable) &&
+    tableTitleKey(group.anchorTable) === tableTitleKey(table) &&
+    group.anchorTable.columns.length === table.columns.length &&
+    hasCompatibleHeaders(group.headerSignatures, table)
+  );
+}
+
+function markRepeatedHeaderRows(table, repeatedSignatures) {
+  if (!Array.isArray(repeatedSignatures) || repeatedSignatures.length === 0) {
+    return table;
+  }
+
+  const repeatedSignatureSet = new Set(repeatedSignatures);
+  const repeatedRowIndexes = new Set();
+
+  for (const row of sortRows(table.rows).slice(0, MAX_LEADING_ROWS)) {
+    if (row.rowType === "footer" || row.rowType === "note") {
+      break;
+    }
+
+    const signature = rowSignature(table, row);
+    if (!signature || !repeatedSignatureSet.has(signature)) {
+      break;
+    }
+
+    repeatedRowIndexes.add(row.rowIndex);
+  }
+
+  if (repeatedRowIndexes.size === 0) {
+    return table;
+  }
+
+  return {
+    ...table,
+    rows: table.rows.map((row) =>
+      repeatedRowIndexes.has(row.rowIndex)
+        ? {
+            ...row,
+            rowType: "header",
+            repeatedHeaderRow: true,
+          }
+        : row
+    ),
+    cells: table.cells.map((cell) => {
+      if (!repeatedRowIndexes.has(cell.rowIndex)) {
+        return cell;
+      }
+      const { inferredHeaders: _inferredHeaders, ...rest } = cell;
+      return {
+        ...rest,
+        isHeader: true,
+      };
+    }),
+    fidelityWarnings: appendWarnings(table, ["repeated-headers-detected"]),
+  };
+}
+
+function withContinuity(table, groupId, indexInGroup, groupSize) {
+  return {
+    ...table,
+    continuity: {
+      ...(table.continuity ?? {}),
+      isMultiPage: groupSize > 1,
+      logicalTableGroupId: groupId,
+      continuedFromPreviousPage: indexInGroup > 0,
+      continuesOnNextPage: indexInGroup < groupSize - 1,
+    },
+  };
+}
+
+function prepareTablesForChunking(normalizedTables) {
+  const groups = [];
+
+  for (const table of normalizedTables) {
+    const currentTable = table;
+    const priorGroup = groups.at(-1);
+    if (priorGroup && shouldMergeIntoGroup(priorGroup, currentTable)) {
+      const withRepeatedHeaders = markRepeatedHeaderRows(
+        currentTable,
+        priorGroup.headerSignatures
+      );
+      priorGroup.tables.push(withRepeatedHeaders);
+      priorGroup.lastTable = withRepeatedHeaders;
+      if (priorGroup.headerSignatures.length === 0) {
+        priorGroup.headerSignatures = headerRowSignatures(withRepeatedHeaders);
+      }
+      continue;
+    }
+
+    groups.push({
+      groupId: `logical-table-${groups.length + 1}`,
+      anchorTable: currentTable,
+      lastTable: currentTable,
+      headerSignatures: headerRowSignatures(currentTable),
+      tables: [currentTable],
+    });
+  }
+
+  const continuityAnnotatedTables = groups.flatMap((group) =>
+    group.tables.map((table, index) =>
+      withContinuity(table, group.groupId, index, group.tables.length)
+    )
+  );
+
+  return mergeMultiPageTables(continuityAnnotatedTables).map((table) => {
+    const inferredTable = inferHeaders(table);
+    return {
+      ...inferredTable,
+      fidelityWarnings: appendWarnings(inferredTable, [
+        inferredTable.continuity?.isMultiPage ? "multi-page-merged" : null,
+        inferredTable.rows.some((row) => row.repeatedHeaderRow)
+          ? "repeated-headers-detected"
+          : null,
+      ]),
+    };
+  });
 }
 
 const rawInput = await readStdin();
@@ -61,13 +280,15 @@ const normalizedTables = input.tables.map((entry, index) => {
   return normalizeFromDocling(entry.tableItem, options);
 });
 
-const tableChunks = normalizedTables.flatMap((table) =>
+const preparedTables = prepareTablesForChunking(normalizedTables);
+
+const tableChunks = preparedTables.flatMap((table) =>
   buildTableChunks(table, chunkOptions)
 );
 
 process.stdout.write(
   JSON.stringify({
-    normalizedTables,
+    normalizedTables: preparedTables,
     tableChunks,
   })
 );


### PR DESCRIPTION
## Summary
- merge adjacent Docling wage-table fragments into one logical TPDS table when they are continuation pages
- detect and suppress repeated continuation headers before TPDS row and row-group chunk generation
- add regression fixtures and tests for multi-page fragments plus grouped-header / merged-cell layouts

## Why
Issue #62 established the Docling + TPDS wage-table branch for #58, but continuation pages were still splitting one logical wage table into multiple TPDS tables and could leak repeated headers into retrieval chunks.

Closes #60.

## What Changed
- updated `services/ingestion/tpds_bridge.mjs` to assign explicit logical table groups, merge adjacent fragments, rerun header inference after merge, and emit continuity / fidelity warnings for debugging
- added Docling fixtures and bridge-backed tests covering multi-page continuation handling and grouped-header / merged-cell preservation
- updated the Docling + TPDS architecture note and ingestion runbook to describe the merged-table behavior and the `tpds.tables.json` signals to inspect

## Validation
- `ruff check .` in `services/ingestion`
- `python3 -m pytest services/ingestion/tests`

## Scope Notes
- leaves non-wage ingestion behavior unchanged
- does not include the corpus reingestion / evaluation rerun tracked in #59
- does not include the artifact / metadata follow-up tracked in #61
