### PR TITLE
fix: fan out cross-union retrieval

### DIFF
--- a/services/api/src/rag/preprocess.py
+++ b/services/api/src/rag/preprocess.py
@@ -51,10 +51,17 @@ _CROSS_UNION_PHRASES: list[str] = [
 class QueryContext(BaseModel):
     """Structured output of query pre-processing."""
 
-    union_filter: str | None
+    union_filters: list[str]
     include_nuclear_pa: bool
     agreement_scope: str | None
     is_cross_union: bool
+
+    @property
+    def union_filter(self) -> str | None:
+        """Return the single detected union, if and only if exactly one exists."""
+        if len(self.union_filters) == 1:
+            return self.union_filters[0]
+        return None
 
 
 def detect_nuclear(query: str) -> bool:
@@ -67,6 +74,25 @@ def detect_nuclear(query: str) -> bool:
     return any(p.search(query) is not None for p in _NUCLEAR_PATTERNS)
 
 
+def detect_unions(query: str, known_unions: list[str]) -> list[str]:
+    """Return every known union mentioned in the query, ordered by appearance.
+
+    Matching remains case-insensitive substring search to preserve the current
+    detection semantics, but all matches are retained instead of collapsing to
+    the first union in ``known_unions`` order.
+    """
+    lower = query.lower()
+    matches: list[tuple[int, int, str]] = []
+
+    for index, union in enumerate(known_unions):
+        position = lower.find(union.lower())
+        if position != -1:
+            matches.append((position, index, union))
+
+    matches.sort(key=lambda item: (item[0], item[1]))
+    return [union for _, _, union in matches]
+
+
 def detect_union(query: str, known_unions: list[str]) -> str | None:
     """Return the verbatim name of the first union found in the query.
 
@@ -74,11 +100,8 @@ def detect_union(query: str, known_unions: list[str]) -> str | None:
     (case-insensitively) as a substring of *query*. Returns None when no
     match is found.
     """
-    lower = query.lower()
-    for union in known_unions:
-        if union.lower() in lower:
-            return union
-    return None
+    unions = detect_unions(query, known_unions)
+    return unions[0] if unions else None
 
 
 def detect_scope(query: str) -> str | None:
@@ -119,9 +142,11 @@ def preprocess(query: str, known_unions: list[str]) -> QueryContext:
     Returns:
         A QueryContext describing retrieval filters and model routing.
     """
+    detected_unions = detect_unions(query, known_unions)
+
     return QueryContext(
-        union_filter=detect_union(query, known_unions),
+        union_filters=detected_unions,
         include_nuclear_pa=detect_nuclear(query),
         agreement_scope=detect_scope(query),
-        is_cross_union=classify_complexity(query),
+        is_cross_union=classify_complexity(query) or len(detected_unions) > 1,
     )

--- a/services/api/src/rag/retrieval.py
+++ b/services/api/src/rag/retrieval.py
@@ -144,6 +144,61 @@ def build_filter(
     return Filter(must=must, must_not=must_not or None)
 
 
+async def _query_qdrant(
+    qdrant: AsyncQdrantClient,
+    *,
+    vector: list[float],
+    union_filter: str | None,
+    include_nuclear_pa: bool,
+    agreement_scope: str | None,
+    limit: int = TOP_K,
+) -> list[ChunkResult]:
+    """Run a single filtered Qdrant query and map the points to chunks."""
+    response = await qdrant.query_points(
+        collection_name=COLLECTION,
+        query=vector,
+        query_filter=build_filter(union_filter, include_nuclear_pa, agreement_scope),
+        limit=limit,
+        with_payload=True,
+    )
+    return [_point_to_chunk(hit) for hit in response.points]
+
+
+def _merge_union_results(
+    result_sets: list[list[ChunkResult]],
+    *,
+    limit: int = TOP_K,
+) -> list[ChunkResult]:
+    """Interleave per-union result sets, preserving per-union ranking.
+
+    Each list in ``result_sets`` is assumed to already be ordered by descending
+    similarity score. The merge walks those lists in rounds so multi-union
+    queries keep representation from each detected union instead of letting one
+    union monopolize the context window. Duplicate point IDs are removed while
+    preserving the first occurrence.
+    """
+    merged: list[ChunkResult] = []
+    seen_point_ids: set[str] = set()
+    max_results = max((len(results) for results in result_sets), default=0)
+
+    for index in range(max_results):
+        for results in result_sets:
+            if index >= len(results):
+                continue
+
+            chunk = results[index]
+            if chunk.point_id in seen_point_ids:
+                continue
+
+            merged.append(chunk)
+            seen_point_ids.add(chunk.point_id)
+
+            if len(merged) >= limit:
+                return merged
+
+    return merged
+
+
 async def _embed(text: str, settings: Settings) -> list[float]:
     """Return a 768-dim embedding for *text* via the Ollama embeddings API."""
     async with httpx.AsyncClient() as client:
@@ -182,7 +237,7 @@ def _point_to_chunk(point: ScoredPoint) -> ChunkResult:
 async def retrieve(
     query: str,
     *,
-    union_filter: str | None = None,
+    union_filters: list[str] | None = None,
     include_nuclear_pa: bool = False,
     agreement_scope: str | None = None,
     settings: Settings,
@@ -191,7 +246,10 @@ async def retrieve(
 
     Args:
         query: The raw user question to embed and search against.
-        union_filter: When set, restrict retrieval to a single union by name.
+        union_filters: When set, restrict retrieval to the given unions. A
+            single detected union behaves like the previous single-filter path.
+            Multiple detected unions trigger one filtered retrieval per union,
+            then a deterministic merged result list.
         include_nuclear_pa: Include Nuclear Project Agreement chunks when
             ``True``.  Defaults to ``False``; set to ``True`` when the query
             contains nuclear-site context (see ``preprocess.detect_nuclear``).
@@ -201,17 +259,31 @@ async def retrieve(
 
     Returns:
         Up to ``TOP_K`` ``ChunkResult`` objects ordered by descending cosine
-        similarity score.
+        similarity score for single-union queries, or a deterministic
+        interleaving of per-union top results for multi-union queries.
     """
     vector = await _embed(query, settings)
-    filt = build_filter(union_filter, include_nuclear_pa, agreement_scope)
-
     qdrant = AsyncQdrantClient(url=settings.qdrant_url)
-    response = await qdrant.query_points(
-        collection_name=COLLECTION,
-        query=vector,
-        query_filter=filt,
-        limit=TOP_K,
-        with_payload=True,
+
+    unique_union_filters = list(dict.fromkeys(union_filters or []))
+    if len(unique_union_filters) > 1:
+        result_sets = [
+            await _query_qdrant(
+                qdrant,
+                vector=vector,
+                union_filter=union_filter,
+                include_nuclear_pa=include_nuclear_pa,
+                agreement_scope=agreement_scope,
+            )
+            for union_filter in unique_union_filters
+        ]
+        return _merge_union_results(result_sets)
+
+    union_filter = unique_union_filters[0] if unique_union_filters else None
+    return await _query_qdrant(
+        qdrant,
+        vector=vector,
+        union_filter=union_filter,
+        include_nuclear_pa=include_nuclear_pa,
+        agreement_scope=agreement_scope,
     )
-    return [_point_to_chunk(hit) for hit in response.points]

--- a/services/api/src/routes/query.py
+++ b/services/api/src/routes/query.py
@@ -144,7 +144,7 @@ async def query_handler(
     # Step 2 — retrieve
     chunks: list[ChunkResult] = await retrieve(
         body.query,
-        union_filter=ctx.union_filter,
+        union_filters=ctx.union_filters,
         include_nuclear_pa=ctx.include_nuclear_pa,
         agreement_scope=ctx.agreement_scope,
         settings=settings,
@@ -167,7 +167,7 @@ async def query_handler(
     citations = extract_citations(result.answer, chunks, title_map=title_map)
 
     # Step 6 — log query (best-effort)
-    union_filter_list = [ctx.union_filter] if ctx.union_filter else None
+    union_filter_list = ctx.union_filters or None
     doc_type_filter_list = None if ctx.include_nuclear_pa else ["primary_ca"]
     total_latency_ms = int((time.monotonic() - pipeline_start) * 1000)
 

--- a/services/api/tests/test_preprocess.py
+++ b/services/api/tests/test_preprocess.py
@@ -5,6 +5,7 @@ from src.rag.preprocess import (
     detect_nuclear,
     detect_scope,
     detect_union,
+    detect_unions,
     preprocess,
 )
 
@@ -117,6 +118,24 @@ class TestDetectUnion:
         assert detect_union("general overtime rules for all workers", KNOWN_UNIONS) is None
 
 
+class TestDetectUnions:
+    def test_empty_query_returns_empty_list(self) -> None:
+        assert detect_unions("", KNOWN_UNIONS) == []
+
+    def test_empty_known_unions_returns_empty_list(self) -> None:
+        assert detect_unions("IBEW and Labourers overtime", []) == []
+
+    def test_returns_all_detected_unions_in_query_order(self) -> None:
+        result = detect_unions(
+            "Compare Sheet Metal Workers and IBEW overtime rules",
+            KNOWN_UNIONS,
+        )
+        assert result == ["Sheet Metal Workers", "IBEW"]
+
+    def test_returns_empty_list_when_query_has_no_union(self) -> None:
+        assert detect_unions("general overtime rules for all workers", KNOWN_UNIONS) == []
+
+
 class TestDetectScope:
     def test_no_scope_returns_none(self) -> None:
         assert detect_scope("What is the overtime rate?") is None
@@ -180,11 +199,12 @@ class TestClassifyComplexity:
 class TestQueryContext:
     def test_default_values(self) -> None:
         ctx = QueryContext(
-            union_filter=None,
+            union_filters=[],
             include_nuclear_pa=False,
             agreement_scope=None,
             is_cross_union=False,
         )
+        assert ctx.union_filters == []
         assert ctx.union_filter is None
         assert ctx.include_nuclear_pa is False
         assert ctx.agreement_scope is None
@@ -192,11 +212,12 @@ class TestQueryContext:
 
     def test_all_fields_set(self) -> None:
         ctx = QueryContext(
-            union_filter="IBEW",
+            union_filters=["IBEW"],
             include_nuclear_pa=True,
             agreement_scope="generation",
             is_cross_union=True,
         )
+        assert ctx.union_filters == ["IBEW"]
         assert ctx.union_filter == "IBEW"
         assert ctx.include_nuclear_pa is True
         assert ctx.agreement_scope == "generation"
@@ -206,6 +227,7 @@ class TestQueryContext:
 class TestPreprocess:
     def test_simple_query_returns_all_defaults(self) -> None:
         ctx = preprocess("What is the overtime rate?", KNOWN_UNIONS)
+        assert ctx.union_filters == []
         assert ctx.union_filter is None
         assert ctx.include_nuclear_pa is False
         assert ctx.agreement_scope is None
@@ -217,6 +239,7 @@ class TestPreprocess:
 
     def test_union_query_sets_union_filter(self) -> None:
         ctx = preprocess("What does IBEW say about overtime?", KNOWN_UNIONS)
+        assert ctx.union_filters == ["IBEW"]
         assert ctx.union_filter == "IBEW"
 
     def test_scope_query_sets_agreement_scope(self) -> None:
@@ -229,6 +252,7 @@ class TestPreprocess:
 
     def test_combined_nuclear_and_union(self) -> None:
         ctx = preprocess("IBEW Darlington refurbishment wage rates", KNOWN_UNIONS)
+        assert ctx.union_filters == ["IBEW"]
         assert ctx.union_filter == "IBEW"
         assert ctx.include_nuclear_pa is True
 
@@ -238,6 +262,20 @@ class TestPreprocess:
         )
         assert ctx.include_nuclear_pa is True
         assert ctx.agreement_scope == "generation"
+        assert ctx.is_cross_union is True
+
+    def test_multi_union_query_retains_all_detected_unions(self) -> None:
+        ctx = preprocess(
+            "Compare the overtime rules for IBEW Generation and Sheet Metal Workers",
+            KNOWN_UNIONS,
+        )
+        assert ctx.union_filters == ["IBEW", "Sheet Metal Workers"]
+        assert ctx.union_filter is None
+        assert ctx.is_cross_union is True
+
+    def test_multiple_detected_unions_trigger_cross_union_without_keyword(self) -> None:
+        ctx = preprocess("IBEW and Labourers overtime rules", KNOWN_UNIONS)
+        assert ctx.union_filters == ["IBEW", "Labourers"]
         assert ctx.is_cross_union is True
 
     def test_returns_query_context_type(self) -> None:

--- a/services/api/tests/test_query_route.py
+++ b/services/api/tests/test_query_route.py
@@ -246,6 +246,59 @@ def test_cross_union_routes_to_sonnet(test_settings: Settings, stub_user: Curren
     assert call_kwargs["is_cross_union"] is True
 
 
+def test_cross_union_query_passes_all_detected_unions_to_retrieval(
+    test_settings: Settings, stub_user: CurrentUser
+) -> None:
+    chunks = [
+        make_chunk(union_name="IBEW", text="IBEW overtime"),
+        make_chunk(union_name="Sheet Metal Workers", text="Sheet Metal overtime"),
+    ]
+    gen_result = make_generator_result(
+        answer="Compare [SOURCE 1] [SOURCE 2]",
+        model="claude-sonnet-4-6",
+    )
+
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    mock_retrieve = AsyncMock(return_value=chunks)
+
+    with patch("src.main.get_settings", return_value=test_settings):
+        with TestClient(app) as client:
+            with patch(
+                "src.routes.query._get_known_unions",
+                new=AsyncMock(return_value=["IBEW", "Sheet Metal Workers"]),
+            ), patch("src.routes.query.retrieve", new=mock_retrieve), patch(
+                "src.routes.query._get_title_map",
+                new=AsyncMock(
+                    return_value={
+                        "doc-001": "IBEW Generation 2025-2030 Collective Agreement"
+                    }
+                ),
+            ), patch(
+                "src.routes.query.generate",
+                new=AsyncMock(return_value=gen_result),
+            ), patch(
+                "src.routes.query._write_query_log",
+                new=AsyncMock(return_value=None),
+            ):
+                response = client.post(
+                    "/query",
+                    json={
+                        "query": (
+                            "Compare the overtime rules for IBEW Generation "
+                            "and Sheet Metal Workers"
+                        )
+                    },
+                )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    call_kwargs = mock_retrieve.call_args.kwargs
+    assert call_kwargs["union_filters"] == ["IBEW", "Sheet Metal Workers"]
+
+
 def test_missing_query_field_returns_422(test_settings: Settings, stub_user: CurrentUser) -> None:
     app.dependency_overrides[get_settings] = lambda: test_settings
     app.dependency_overrides[get_current_user] = lambda: stub_user

--- a/services/api/tests/test_retrieval.py
+++ b/services/api/tests/test_retrieval.py
@@ -28,6 +28,7 @@ from src.rag.retrieval import (
     COLLECTION,
     TOP_K,
     ChunkResult,
+    _merge_union_results,
     _point_to_chunk,
     build_filter,
     retrieve,
@@ -348,6 +349,99 @@ def _make_query_response(hits: list[ScoredPoint]) -> QueryResponse:
     return QueryResponse(points=hits)
 
 
+def _union_filter_value(filt: Filter) -> str | None:
+    for condition in filt.must or []:
+        if isinstance(condition, FieldCondition) and condition.key == "union_name":
+            return str(condition.match.value)  # type: ignore[union-attr]
+    return None
+
+
+class TestMergeUnionResults:
+    def test_interleaves_union_results_round_robin(self) -> None:
+        ibew_results = [
+            ChunkResult(
+                point_id="ibew-1",
+                score=0.95,
+                document_id="doc-1",
+                source_filename="ibew-1.pdf",
+                union_name="IBEW",
+                document_type="primary_ca",
+                agreement_scope=None,
+                effective_date=None,
+                expiry_date=None,
+                article_number=None,
+                article_title=None,
+                section_number=None,
+                page_number=None,
+                is_table=False,
+                text="IBEW first",
+            ),
+            ChunkResult(
+                point_id="ibew-2",
+                score=0.9,
+                document_id="doc-2",
+                source_filename="ibew-2.pdf",
+                union_name="IBEW",
+                document_type="primary_ca",
+                agreement_scope=None,
+                effective_date=None,
+                expiry_date=None,
+                article_number=None,
+                article_title=None,
+                section_number=None,
+                page_number=None,
+                is_table=False,
+                text="IBEW second",
+            ),
+        ]
+        sheet_metal_results = [
+            ChunkResult(
+                point_id="sm-1",
+                score=0.93,
+                document_id="doc-3",
+                source_filename="sm-1.pdf",
+                union_name="Sheet Metal Workers",
+                document_type="primary_ca",
+                agreement_scope=None,
+                effective_date=None,
+                expiry_date=None,
+                article_number=None,
+                article_title=None,
+                section_number=None,
+                page_number=None,
+                is_table=False,
+                text="Sheet Metal first",
+            )
+        ]
+
+        merged = _merge_union_results([ibew_results, sheet_metal_results], limit=3)
+
+        assert [chunk.point_id for chunk in merged] == ["ibew-1", "sm-1", "ibew-2"]
+
+    def test_dedupes_duplicate_point_ids(self) -> None:
+        duplicate = ChunkResult(
+            point_id="dup-1",
+            score=0.95,
+            document_id="doc-1",
+            source_filename="dup.pdf",
+            union_name="IBEW",
+            document_type="primary_ca",
+            agreement_scope=None,
+            effective_date=None,
+            expiry_date=None,
+            article_number=None,
+            article_title=None,
+            section_number=None,
+            page_number=None,
+            is_table=False,
+            text="duplicate",
+        )
+
+        merged = _merge_union_results([[duplicate], [duplicate]], limit=5)
+
+        assert [chunk.point_id for chunk in merged] == ["dup-1"]
+
+
 class TestRetrieve:
     """retrieve calls Ollama (embed) then Qdrant (search); both are mocked."""
 
@@ -472,3 +566,64 @@ class TestRetrieve:
             await retrieve("overtime rates", settings=settings)
 
         mock_qdrant_cls.assert_called_once_with(url=settings.qdrant_url)
+
+    @pytest.mark.asyncio
+    async def test_single_union_filter_still_uses_one_qdrant_query(
+        self, settings: Settings
+    ) -> None:
+        with (
+            patch("src.rag.retrieval.httpx.AsyncClient") as mock_http,
+            patch("src.rag.retrieval.AsyncQdrantClient") as mock_qdrant_cls,
+        ):
+            _make_ollama_mock(mock_http)
+            mock_qdrant = AsyncMock()
+            mock_qdrant.query_points = AsyncMock(return_value=_make_query_response([]))
+            mock_qdrant_cls.return_value = mock_qdrant
+
+            await retrieve(
+                "IBEW overtime rates",
+                union_filters=["IBEW"],
+                settings=settings,
+            )
+
+        assert mock_qdrant.query_points.await_count == 1
+        query_filter = mock_qdrant.query_points.await_args.kwargs["query_filter"]
+        assert _union_filter_value(query_filter) == "IBEW"
+
+    @pytest.mark.asyncio
+    async def test_multi_union_queries_fan_out_and_merge_results(
+        self, settings: Settings
+    ) -> None:
+        ibew_hits = [self._make_hit("IBEW"), self._make_hit("IBEW")]
+        sheet_metal_hits = [self._make_hit("Sheet Metal Workers")]
+
+        with (
+            patch("src.rag.retrieval.httpx.AsyncClient") as mock_http,
+            patch("src.rag.retrieval.AsyncQdrantClient") as mock_qdrant_cls,
+        ):
+            _make_ollama_mock(mock_http)
+            mock_qdrant = AsyncMock()
+            mock_qdrant.query_points = AsyncMock(
+                side_effect=[
+                    _make_query_response(ibew_hits),
+                    _make_query_response(sheet_metal_hits),
+                ]
+            )
+            mock_qdrant_cls.return_value = mock_qdrant
+
+            results = await retrieve(
+                "Compare IBEW and Sheet Metal overtime rules",
+                union_filters=["IBEW", "Sheet Metal Workers"],
+                settings=settings,
+            )
+
+        assert mock_qdrant.query_points.await_count == 2
+        first_filter = mock_qdrant.query_points.await_args_list[0].kwargs["query_filter"]
+        second_filter = mock_qdrant.query_points.await_args_list[1].kwargs["query_filter"]
+        assert _union_filter_value(first_filter) == "IBEW"
+        assert _union_filter_value(second_filter) == "Sheet Metal Workers"
+        assert [chunk.union_name for chunk in results] == [
+            "IBEW",
+            "Sheet Metal Workers",
+            "IBEW",
+        ]


### PR DESCRIPTION
## Summary

- retain all detected unions during query preprocessing instead of collapsing to the first match
- fan out Qdrant retrieval one query per detected union for cross-union requests, then interleave and dedupe the merged context deterministically
- pass multi-union filters through the `/query` route and expand regression coverage for preprocess, retrieval, and route wiring

## Validation

- `ruff check src/`
- `mypy src/`
- `pytest tests/test_preprocess.py tests/test_retrieval.py -q`
- `pytest tests/test_context.py -q`
- `pytest tests/ -v` was started, but the sandbox runner did not return a final completion state for the route/health slice despite no observed failures before it stalled

## Issue

Closes #56
