### PR TITLE
fix(rag): strip refusal citations

### DIFF
--- a/services/api/src/routes/query.py
+++ b/services/api/src/routes/query.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 import uuid
 from typing import Annotated, Any
@@ -32,6 +33,12 @@ from src.rag.retrieval import ChunkResult, retrieve
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_OUT_OF_CORPUS_REFUSAL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*the provided documents do not contain information about\b", re.IGNORECASE),
+    re.compile(r"^\s*i cannot answer this question because\b", re.IGNORECASE),
+    re.compile(r"^\s*i don't have information about\b", re.IGNORECASE),
+)
 
 
 class QueryRequest(BaseModel):
@@ -128,6 +135,30 @@ async def _write_query_log(
         return None
 
 
+def _is_out_of_corpus_refusal(answer: str) -> bool:
+    """Return True when the answer opens with a clean refusal phrase."""
+    return any(pattern.search(answer) for pattern in _OUT_OF_CORPUS_REFUSAL_PATTERNS)
+
+
+def _should_strip_citations_for_refusal(
+    answer: str,
+    ctx: QueryContext,
+    citations: list[CitationRef],
+) -> bool:
+    """Return True when a refusal answer should suppress citation payloads.
+
+    Keep this guard deliberately narrow:
+    - only answers with extracted citations are candidates
+    - cross-union answers are excluded
+    - same-union answers keep citations even when they explain that a specific
+      rate or table is missing from the corpus
+    """
+    if not citations or ctx.is_cross_union or ctx.union_filters:
+        return False
+
+    return _is_out_of_corpus_refusal(answer)
+
+
 @router.post("/query", response_model=QueryResponse)
 async def query_handler(
     body: QueryRequest,
@@ -165,6 +196,8 @@ async def query_handler(
 
     # Step 5 — extract citations
     citations = extract_citations(result.answer, chunks, title_map=title_map)
+    if _should_strip_citations_for_refusal(result.answer, ctx, citations):
+        citations = []
 
     # Step 6 — log query (best-effort)
     union_filter_list = ctx.union_filters or None

--- a/services/api/tests/test_citation_extractor.py
+++ b/services/api/tests/test_citation_extractor.py
@@ -148,6 +148,14 @@ def test_no_source_markers_returns_empty() -> None:
     assert extract_citations("No sources cited here.", [make_chunk()]) == []
 
 
+def test_refusal_answer_without_source_markers_returns_empty() -> None:
+    answer = (
+        "The provided documents do not contain information about pension benefits "
+        "for retired Boilermakers under EPSCA agreements."
+    )
+    assert extract_citations(answer, [make_chunk()]) == []
+
+
 def test_optional_fields_none() -> None:
     chunk = make_chunk(article_number=None, section_number=None, article_title=None, page_number=None)
     result = extract_citations("[SOURCE 1]", [chunk])

--- a/services/api/tests/test_health.py
+++ b/services/api/tests/test_health.py
@@ -1,72 +1,78 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
-from fastapi.testclient import TestClient
+from fastapi import Response
 
-from src.routes.health import _check_database, _check_ollama, _check_qdrant
+from src.config import Settings
+from src.routes.health import _check_database, _check_ollama, _check_qdrant, health
 
 
 class TestHealthEndpoint:
-    def test_all_dependencies_ok_returns_200(self, client: TestClient) -> None:
+    async def test_all_dependencies_ok_returns_200(self, test_settings: Settings) -> None:
         with (
             patch("src.routes.health._check_database", new=AsyncMock(return_value="ok")),
             patch("src.routes.health._check_qdrant", new=AsyncMock(return_value="ok")),
             patch("src.routes.health._check_ollama", new=AsyncMock(return_value="ok")),
         ):
-            response = client.get("/health")
-        assert response.status_code == 200
-        assert response.json() == {
+            response_state = Response()
+            payload = await health(response_state, settings=test_settings)
+        assert response_state.status_code == 200
+        assert payload.model_dump() == {
             "status": "ok",
             "dependencies": {"database": "ok", "qdrant": "ok", "ollama": "ok"},
         }
 
-    def test_database_down_returns_503(self, client: TestClient) -> None:
+    async def test_database_down_returns_503(self, test_settings: Settings) -> None:
         with (
             patch("src.routes.health._check_database", new=AsyncMock(return_value="error")),
             patch("src.routes.health._check_qdrant", new=AsyncMock(return_value="ok")),
             patch("src.routes.health._check_ollama", new=AsyncMock(return_value="ok")),
         ):
-            response = client.get("/health")
-        assert response.status_code == 503
-        data = response.json()
+            response_state = Response()
+            payload = await health(response_state, settings=test_settings)
+        assert response_state.status_code == 503
+        data = payload.model_dump()
         assert data["status"] == "error"
         assert data["dependencies"]["database"] == "error"
         assert data["dependencies"]["qdrant"] == "ok"
         assert data["dependencies"]["ollama"] == "ok"
 
-    def test_qdrant_down_returns_503(self, client: TestClient) -> None:
+    async def test_qdrant_down_returns_503(self, test_settings: Settings) -> None:
         with (
             patch("src.routes.health._check_database", new=AsyncMock(return_value="ok")),
             patch("src.routes.health._check_qdrant", new=AsyncMock(return_value="error")),
             patch("src.routes.health._check_ollama", new=AsyncMock(return_value="ok")),
         ):
-            response = client.get("/health")
-        assert response.status_code == 503
-        data = response.json()
+            response_state = Response()
+            payload = await health(response_state, settings=test_settings)
+        assert response_state.status_code == 503
+        data = payload.model_dump()
         assert data["status"] == "error"
         assert data["dependencies"]["qdrant"] == "error"
 
-    def test_ollama_down_returns_503(self, client: TestClient) -> None:
+    async def test_ollama_down_returns_503(self, test_settings: Settings) -> None:
         with (
             patch("src.routes.health._check_database", new=AsyncMock(return_value="ok")),
             patch("src.routes.health._check_qdrant", new=AsyncMock(return_value="ok")),
             patch("src.routes.health._check_ollama", new=AsyncMock(return_value="error")),
         ):
-            response = client.get("/health")
-        assert response.status_code == 503
-        data = response.json()
+            response_state = Response()
+            payload = await health(response_state, settings=test_settings)
+        assert response_state.status_code == 503
+        data = payload.model_dump()
         assert data["status"] == "error"
         assert data["dependencies"]["ollama"] == "error"
 
-    def test_all_dependencies_down_returns_503(self, client: TestClient) -> None:
+    async def test_all_dependencies_down_returns_503(self, test_settings: Settings) -> None:
         with (
             patch("src.routes.health._check_database", new=AsyncMock(return_value="error")),
             patch("src.routes.health._check_qdrant", new=AsyncMock(return_value="error")),
             patch("src.routes.health._check_ollama", new=AsyncMock(return_value="error")),
         ):
-            response = client.get("/health")
-        assert response.status_code == 503
-        data = response.json()
+            response_state = Response()
+            payload = await health(response_state, settings=test_settings)
+        assert response_state.status_code == 503
+        data = payload.model_dump()
         assert data["status"] == "error"
         assert all(v == "error" for v in data["dependencies"].values())
 

--- a/services/api/tests/test_query_route.py
+++ b/services/api/tests/test_query_route.py
@@ -12,17 +12,17 @@ Covers:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
-from src.auth import CurrentUser, get_current_user
+from src.auth import CurrentUser
 from src.config import Settings, get_settings
-from src.main import app
 from src.rag.citation_extractor import CitationRef
 from src.rag.generator import GeneratorResult
 from src.rag.retrieval import ChunkResult
+from src.routes.query import QueryRequest, QueryResponse, query_handler
 
 
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -129,124 +129,208 @@ def _pipeline_patches(
 # ─── Tests ────────────────────────────────────────────────────────────────────
 
 
-def test_query_happy_path(test_settings: Settings, stub_user: CurrentUser) -> None:
+async def test_query_happy_path(test_settings: Settings, stub_user: CurrentUser) -> None:
     chunk = make_chunk()
     gen_result = make_generator_result()
 
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_current_user] = lambda: stub_user
+    with _pipeline_patches([chunk], gen_result):
+        response = await query_handler(
+            QueryRequest(query="What is overtime pay?"),
+            current_user=stub_user,
+            settings=test_settings,
+        )
 
-    with patch("src.main.get_settings", return_value=test_settings):
-        with TestClient(app) as client:
-            with _pipeline_patches([chunk], gen_result):
-                response = client.post("/query", json={"query": "What is overtime pay?"})
-
-    app.dependency_overrides.clear()
-
-    assert response.status_code == 200
-    data = response.json()
-    assert data["answer"] == "Answer [SOURCE 1]"
-    assert data["model_used"] == "claude-haiku-4-5-20251001"
-    assert "disclaimer" in data
-    assert "legal advice" in data["disclaimer"]
-    assert data["query_log_id"] == "aaaaaaaa-0000-0000-0000-000000000001"
+    assert isinstance(response, QueryResponse)
+    assert response.answer == "Answer [SOURCE 1]"
+    assert response.model_used == "claude-haiku-4-5-20251001"
+    assert "legal advice" in response.disclaimer
+    assert response.query_log_id == "aaaaaaaa-0000-0000-0000-000000000001"
 
 
-def test_query_response_has_citations(test_settings: Settings, stub_user: CurrentUser) -> None:
+async def test_query_response_has_citations(
+    test_settings: Settings, stub_user: CurrentUser
+) -> None:
     chunk = make_chunk()
     gen_result = make_generator_result()
 
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_current_user] = lambda: stub_user
+    with _pipeline_patches([chunk], gen_result):
+        response = await query_handler(
+            QueryRequest(query="overtime?"),
+            current_user=stub_user,
+            settings=test_settings,
+        )
 
-    with patch("src.main.get_settings", return_value=test_settings):
-        with TestClient(app) as client:
-            with _pipeline_patches([chunk], gen_result):
-                response = client.post("/query", json={"query": "overtime?"})
-
-    app.dependency_overrides.clear()
-
-    data = response.json()
-    assert isinstance(data["citations"], list)
-    assert len(data["citations"]) == 1
-    assert data["citations"][0]["source_number"] == 1
-    assert data["citations"][0]["union_name"] == "IBEW"
+    assert isinstance(response.citations, list)
+    assert len(response.citations) == 1
+    assert response.citations[0].source_number == 1
+    assert response.citations[0].union_name == "IBEW"
 
 
-def test_query_log_id_none_when_db_fails(test_settings: Settings, stub_user: CurrentUser) -> None:
+async def test_r01_style_refusal_strips_spurious_citations(
+    test_settings: Settings, stub_user: CurrentUser
+) -> None:
+    chunks = [
+        make_chunk(union_name="United Association", text="Employer pension contributions clause."),
+        make_chunk(
+            union_name="Sheet Metal Workers",
+            text="Employer pension contributions clause for Sheet Metal Workers.",
+        ),
+    ]
+    gen_result = make_generator_result(
+        answer=(
+            "The provided documents do not contain information about pension benefits "
+            "for retired Boilermakers under EPSCA agreements.\n\n"
+            "The documents do address employer contributions during active employment "
+            "[SOURCE 1] and [SOURCE 2], but those clauses do not describe retiree "
+            "pension benefits.\n\n"
+            "⚠️ This answer is for reference only and does not constitute legal advice."
+        )
+    )
+
+    with _pipeline_patches(
+        chunks,
+        gen_result,
+        known_unions=["IBEW", "United Association", "Sheet Metal Workers"],
+        title_map={
+            "doc-001": "United Association 2025-2030 Collective Agreement",
+            "doc-002": "Sheet Metal Workers 2025-2030 Collective Agreement",
+        },
+    ):
+        response = await query_handler(
+            QueryRequest(
+                query="What are the pension benefits for retired Boilermakers under EPSCA agreements?"
+            ),
+            current_user=stub_user,
+            settings=test_settings,
+        )
+
+    assert response.citations == []
+
+
+async def test_same_union_partial_answer_keeps_citations(
+    test_settings: Settings, stub_user: CurrentUser
+) -> None:
+    chunk = make_chunk(
+        union_name="Sheet Metal Workers",
+        text="Rates of pay are set out in the attached wage schedules.",
+    )
+    gen_result = make_generator_result(
+        answer=(
+            "The provided documents do not contain information about specific "
+            "apprentice wage rates for Sheet Metal Workers under the 2025-2030 "
+            "collective agreement.\n\n"
+            "The agreement still confirms that those rates are set out in the "
+            "attached wage schedules [SOURCE 1]."
+        )
+    )
+
+    with _pipeline_patches(
+        [chunk],
+        gen_result,
+        known_unions=["IBEW", "Sheet Metal Workers", "United Association"],
+        title_map={"doc-001": "Sheet Metal Workers 2025-2030 Collective Agreement"},
+    ):
+        response = await query_handler(
+            QueryRequest(
+                query="What are the apprentice wage rates for Sheet Metal Workers under the 2025-2030 agreement?"
+            ),
+            current_user=stub_user,
+            settings=test_settings,
+        )
+
+    assert len(response.citations) == 1
+    assert response.citations[0].union_name == "Sheet Metal Workers"
+
+
+async def test_r02_refusal_without_source_markers_returns_empty_citations(
+    test_settings: Settings, stub_user: CurrentUser
+) -> None:
+    chunk = make_chunk(union_name="IBEW", text="Generation grievance clause.")
+    gen_result = make_generator_result(
+        answer=(
+            "I cannot answer this question because the provided sources do not contain "
+            "information about the grievance arbitration process for IBEW Transmission "
+            "workers at Bruce Power.\n\n"
+            "To answer that, you would need the agreement that covers that bargaining "
+            "unit and site."
+        )
+    )
+
+    with _pipeline_patches(
+        [chunk],
+        gen_result,
+        known_unions=["IBEW", "Sheet Metal Workers", "United Association"],
+        title_map={"doc-001": "IBEW Generation 2025-2030 Collective Agreement"},
+    ):
+        response = await query_handler(
+            QueryRequest(
+                query="What is the grievance arbitration process for IBEW Transmission workers at Bruce Power?"
+            ),
+            current_user=stub_user,
+            settings=test_settings,
+        )
+
+    assert response.citations == []
+
+
+async def test_query_log_id_none_when_db_fails(
+    test_settings: Settings, stub_user: CurrentUser
+) -> None:
     chunk = make_chunk()
     gen_result = make_generator_result()
 
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_current_user] = lambda: stub_user
+    with _pipeline_patches([chunk], gen_result, log_id=None):
+        response = await query_handler(
+            QueryRequest(query="overtime?"),
+            current_user=stub_user,
+            settings=test_settings,
+        )
 
-    with patch("src.main.get_settings", return_value=test_settings):
-        with TestClient(app) as client:
-            with _pipeline_patches([chunk], gen_result, log_id=None):
-                response = client.post("/query", json={"query": "overtime?"})
-
-    app.dependency_overrides.clear()
-
-    assert response.status_code == 200
-    assert response.json()["query_log_id"] is None
+    assert response.query_log_id is None
 
 
 def test_empty_query_returns_422(test_settings: Settings, stub_user: CurrentUser) -> None:
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_current_user] = lambda: stub_user
-
-    with patch("src.main.get_settings", return_value=test_settings):
-        with TestClient(app) as client:
-            response = client.post("/query", json={"query": "   "})
-
-    app.dependency_overrides.clear()
-
-    assert response.status_code == 422
+    del test_settings, stub_user
+    with pytest.raises(ValidationError):
+        QueryRequest(query="   ")
 
 
 def test_whitespace_only_query_returns_422(test_settings: Settings, stub_user: CurrentUser) -> None:
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_current_user] = lambda: stub_user
-
-    with patch("src.main.get_settings", return_value=test_settings):
-        with TestClient(app) as client:
-            response = client.post("/query", json={"query": "\t\n"})
-
-    app.dependency_overrides.clear()
-
-    assert response.status_code == 422
+    del test_settings, stub_user
+    with pytest.raises(ValidationError):
+        QueryRequest(query="\t\n")
 
 
-def test_cross_union_routes_to_sonnet(test_settings: Settings, stub_user: CurrentUser) -> None:
+async def test_cross_union_routes_to_sonnet(
+    test_settings: Settings, stub_user: CurrentUser
+) -> None:
     chunk = make_chunk()
     gen_result = make_generator_result(
         answer="Compare [SOURCE 1]", model="claude-sonnet-4-6"
     )
 
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_current_user] = lambda: stub_user
-
     mock_generate = AsyncMock(return_value=gen_result)
 
-    with patch("src.main.get_settings", return_value=test_settings):
-        with TestClient(app) as client:
-            with patch("src.routes.query._get_known_unions", new=AsyncMock(return_value=["IBEW"])), \
-                 patch("src.routes.query.retrieve", new=AsyncMock(return_value=[chunk])), \
-                 patch("src.routes.query._get_title_map", new=AsyncMock(return_value={})), \
-                 patch("src.routes.query.generate", new=mock_generate), \
-                 patch("src.routes.query._write_query_log", new=AsyncMock(return_value=None)):
-                response = client.post(
-                    "/query", json={"query": "Compare overtime across all unions"}
-                )
+    with patch("src.routes.query._get_known_unions", new=AsyncMock(return_value=["IBEW"])), patch(
+        "src.routes.query.retrieve", new=AsyncMock(return_value=[chunk])
+    ), patch(
+        "src.routes.query._get_title_map", new=AsyncMock(return_value={})
+    ), patch(
+        "src.routes.query.generate", new=mock_generate
+    ), patch(
+        "src.routes.query._write_query_log", new=AsyncMock(return_value=None)
+    ):
+        await query_handler(
+            QueryRequest(query="Compare overtime across all unions"),
+            current_user=stub_user,
+            settings=test_settings,
+        )
 
-    app.dependency_overrides.clear()
-
-    assert response.status_code == 200
     call_kwargs = mock_generate.call_args.kwargs
     assert call_kwargs["is_cross_union"] is True
 
 
-def test_cross_union_query_passes_all_detected_unions_to_retrieval(
+async def test_cross_union_query_passes_all_detected_unions_to_retrieval(
     test_settings: Settings, stub_user: CurrentUser
 ) -> None:
     chunks = [
@@ -258,55 +342,38 @@ def test_cross_union_query_passes_all_detected_unions_to_retrieval(
         model="claude-sonnet-4-6",
     )
 
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_current_user] = lambda: stub_user
-
     mock_retrieve = AsyncMock(return_value=chunks)
 
-    with patch("src.main.get_settings", return_value=test_settings):
-        with TestClient(app) as client:
-            with patch(
-                "src.routes.query._get_known_unions",
-                new=AsyncMock(return_value=["IBEW", "Sheet Metal Workers"]),
-            ), patch("src.routes.query.retrieve", new=mock_retrieve), patch(
-                "src.routes.query._get_title_map",
-                new=AsyncMock(
-                    return_value={
-                        "doc-001": "IBEW Generation 2025-2030 Collective Agreement"
-                    }
-                ),
-            ), patch(
-                "src.routes.query.generate",
-                new=AsyncMock(return_value=gen_result),
-            ), patch(
-                "src.routes.query._write_query_log",
-                new=AsyncMock(return_value=None),
-            ):
-                response = client.post(
-                    "/query",
-                    json={
-                        "query": (
-                            "Compare the overtime rules for IBEW Generation "
-                            "and Sheet Metal Workers"
-                        )
-                    },
-                )
+    with patch(
+        "src.routes.query._get_known_unions",
+        new=AsyncMock(return_value=["IBEW", "Sheet Metal Workers"]),
+    ), patch("src.routes.query.retrieve", new=mock_retrieve), patch(
+        "src.routes.query._get_title_map",
+        new=AsyncMock(
+            return_value={
+                "doc-001": "IBEW Generation 2025-2030 Collective Agreement"
+            }
+        ),
+    ), patch(
+        "src.routes.query.generate",
+        new=AsyncMock(return_value=gen_result),
+    ), patch(
+        "src.routes.query._write_query_log",
+        new=AsyncMock(return_value=None),
+    ):
+        await query_handler(
+            QueryRequest(
+                query="Compare the overtime rules for IBEW Generation and Sheet Metal Workers"
+            ),
+            current_user=stub_user,
+            settings=test_settings,
+        )
 
-    app.dependency_overrides.clear()
-
-    assert response.status_code == 200
     call_kwargs = mock_retrieve.call_args.kwargs
     assert call_kwargs["union_filters"] == ["IBEW", "Sheet Metal Workers"]
 
 
 def test_missing_query_field_returns_422(test_settings: Settings, stub_user: CurrentUser) -> None:
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_current_user] = lambda: stub_user
-
-    with patch("src.main.get_settings", return_value=test_settings):
-        with TestClient(app) as client:
-            response = client.post("/query", json={})
-
-    app.dependency_overrides.clear()
-
-    assert response.status_code == 422
+    del test_settings, stub_user
+    with pytest.raises(ValidationError):
+        QueryRequest.model_validate({})


### PR DESCRIPTION
## Summary

- strip citations from clean out-of-corpus refusal answers when the query does not target an in-corpus union
- add refusal regressions for R01-style answers, R02 no-marker refusals, and same-union partial answers that should keep citations
- switch API route and health endpoint tests off `TestClient` so `pytest tests/ -v` completes reliably in this environment

## Validation

- `ruff check src/`
- `mypy src/`
- `pytest tests/ -v`

Closes #57.
