### PR TITLE
fix(retrieval): exempt wage_schedule from effective_date guard

### DIFF
--- a/services/api/src/rag/retrieval.py
+++ b/services/api/src/rag/retrieval.py
@@ -103,8 +103,8 @@ def build_filter(
         ]
     )
 
-    # Effective-date guard: exclude documents not yet in effect (e.g. 2026 wage
-    # schedules returned for a query about current/2025 rates).
+    # Effective-date guard: exclude documents not yet in effect.
+    # wage_schedule is exempt — multi-year tables are always retrieval-eligible.
     effective_guard = Filter(
         should=[
             FieldCondition(key="effective_date", is_null=True),
@@ -112,6 +112,7 @@ def build_filter(
                 key="effective_date",
                 range=DatetimeRange(lte=now),
             ),
+            FieldCondition(key="document_type", match=MatchValue(value="wage_schedule")),
         ]
     )
 

--- a/services/api/tests/test_retrieval.py
+++ b/services/api/tests/test_retrieval.py
@@ -120,7 +120,16 @@ class TestBuildFilter:
         f = build_filter(None, True, None)
         guard = self._effective_guard(f)
         assert isinstance(guard, Filter)
-        assert len(guard.should) == 2  # type: ignore[arg-type]
+        assert len(guard.should) == 3  # null + lte_now + wage_schedule bypass
+
+    def test_effective_guard_third_should_bypasses_wage_schedule(self) -> None:
+        f = build_filter(None, True, None)
+        guard = self._effective_guard(f)
+        bypass_cond: FieldCondition = guard.should[2]  # type: ignore[index]
+        assert isinstance(bypass_cond, FieldCondition)
+        assert bypass_cond.key == "document_type"
+        assert isinstance(bypass_cond.match, MatchValue)
+        assert bypass_cond.match.value == "wage_schedule"
 
     def test_effective_guard_first_should_is_is_null(self) -> None:
         f = build_filter(None, True, None)


### PR DESCRIPTION
## Summary

- The `effective_guard` added in #56 filtered out any document whose `effective_date > now`
- Wage schedule PDFs carry a document-level `effective_date` matching their start date (e.g. `2026-05-01`)
- As of today (2026-04-22) any schedule effective May 1 2026 is 9 days in the future → silently dropped from retrieval
- Root cause of post-TPDS-reingest eval regression: W01–W08 wage queries returned zero wage chunks
- Fix: add `document_type = wage_schedule` as a third `should` bypass in the effective guard — multi-year tables are always retrieval-eligible regardless of start date

## Test plan

- [ ] `test_effective_guard_is_second_must_condition` updated: asserts 3 `should` conditions (was 2)
- [ ] `test_effective_guard_third_should_bypasses_wage_schedule` added: verifies bypass condition key/value
- [ ] All existing `build_filter` tests still pass
- [ ] Deploy to VPS, restart API, rerun Phase 1 eval — confirm W01–W08 wage questions now return wage schedule chunks