### PR TITLE
fix(ingestion): propagate classification cells in hierarchical wage tables

### DIFF
--- a/services/ingestion/tpds_bridge.mjs
+++ b/services/ingestion/tpds_bridge.mjs
@@ -176,6 +176,39 @@ function markRepeatedHeaderRows(table, repeatedSignatures) {
   };
 }
 
+function propagateClassificationCells(table) {
+  const bodyRows = sortRows(table.rows).filter(
+    (row) => row.rowType !== "header" && row.rowType !== "footer" && row.rowType !== "note"
+  );
+  if (bodyRows.length === 0) return table;
+
+  const lastSeenByCol = new Map();
+  const cellFills = new Map();
+
+  for (const row of bodyRows) {
+    for (const cell of cellsForRow(table, row)) {
+      const text = normalizeText(cell.textNormalized || cell.textRaw || "");
+      if (text) {
+        lastSeenByCol.set(cell.colIndex, text);
+      } else if (lastSeenByCol.has(cell.colIndex)) {
+        cellFills.set(cell.cellId, lastSeenByCol.get(cell.colIndex));
+      }
+    }
+  }
+
+  if (cellFills.size === 0) return table;
+
+  return {
+    ...table,
+    cells: table.cells.map((cell) =>
+      cellFills.has(cell.cellId)
+        ? { ...cell, textNormalized: cellFills.get(cell.cellId), classificationFilled: true }
+        : cell
+    ),
+    fidelityWarnings: appendWarnings(table, ["classification-propagated"]),
+  };
+}
+
 function withContinuity(table, groupId, indexInGroup, groupSize) {
   return {
     ...table,
@@ -280,7 +313,9 @@ const normalizedTables = input.tables.map((entry, index) => {
   return normalizeFromDocling(entry.tableItem, options);
 });
 
-const preparedTables = prepareTablesForChunking(normalizedTables);
+const preparedTables = prepareTablesForChunking(
+  normalizedTables.map(propagateClassificationCells)
+);
 
 const tableChunks = preparedTables.flatMap((table) =>
   buildTableChunks(table, chunkOptions)


### PR DESCRIPTION
## Summary

- Wage schedule PDFs use hierarchical multi-row tables: classification label ("Journeyperson") appears once in an anchor row; all subsequent date/rate rows leave that cell empty
- TPDS chunks rows independently, so rate chunks lost their classification context — root cause of W01, W04, W07 Phase 1 eval failures
- Adds `propagateClassificationCells()` to `tpds_bridge.mjs`: walks body rows in sorted order, tracks last non-empty text per column index, fills empty cells forward before `prepareTablesForChunking()` is called
- Filled cells are flagged `classificationFilled: true` with a `"classification-propagated"` fidelity warning; tables with no empty body cells return unchanged

Closes #68

## Test plan

- [ ] Reingest wage schedules on VPS (`INGEST_DOC_TYPE=wage_schedule python3 run_pipeline.py`)
- [ ] Rerun Phase 1 eval (`python3 services/api/eval/run_eval.py`)
- [ ] Confirm W01, W04, W07 pass (journeyperson base rate queries)
- [ ] Confirm no regression on W02, W03, W05, W06, W08, W09, W10 (other wage queries)
- [ ] Confirm R01/R02 refusal questions unaffected