### PR TITLE
fix(retrieval): secondary wage_schedule retrieval pass for rate queries

### DIFF
--- a/services/api/src/rag/preprocess.py
+++ b/services/api/src/rag/preprocess.py
@@ -47,6 +47,22 @@ _CROSS_UNION_PHRASES: list[str] = [
     "across trades",
 ]
 
+_WAGE_KEYWORDS: list[str] = [
+    "rate",
+    "wage",
+    "pay",
+    "hourly",
+    "salary",
+    "earn",
+    "journeyperson",
+    "journeyman",
+    "apprentice",
+    "compensation",
+    "base rate",
+    "base pay",
+    "total package",
+]
+
 
 class QueryContext(BaseModel):
     """Structured output of query pre-processing."""
@@ -55,6 +71,7 @@ class QueryContext(BaseModel):
     include_nuclear_pa: bool
     agreement_scope: str | None
     is_cross_union: bool
+    is_wage_query: bool
 
     @property
     def union_filter(self) -> str | None:
@@ -131,6 +148,17 @@ def classify_complexity(query: str) -> bool:
     return any(phrase in lower for phrase in _CROSS_UNION_PHRASES)
 
 
+def detect_wage_query(query: str) -> bool:
+    """Return True if the query is asking about wages, rates, or pay.
+
+    Triggers a secondary wage_schedule-focused retrieval pass to ensure
+    tabular wage data is included in context even when CA narrative text
+    scores higher in the primary similarity search.
+    """
+    lower = query.lower()
+    return any(kw in lower for kw in _WAGE_KEYWORDS)
+
+
 def preprocess(query: str, known_unions: list[str]) -> QueryContext:
     """Analyse *query* and return a populated QueryContext.
 
@@ -149,4 +177,5 @@ def preprocess(query: str, known_unions: list[str]) -> QueryContext:
         include_nuclear_pa=detect_nuclear(query),
         agreement_scope=detect_scope(query),
         is_cross_union=classify_complexity(query) or len(detected_unions) > 1,
+        is_wage_query=detect_wage_query(query),
     )

--- a/services/api/src/rag/retrieval.py
+++ b/services/api/src/rag/retrieval.py
@@ -235,12 +235,65 @@ def _point_to_chunk(point: ScoredPoint) -> ChunkResult:
     )
 
 
+async def _query_wage_schedules(
+    qdrant: AsyncQdrantClient,
+    *,
+    vector: list[float],
+    union_filter: str | None,
+    limit: int = 5,
+) -> list[ChunkResult]:
+    """Return top wage_schedule chunks regardless of general similarity rank.
+
+    Wage schedule chunks are tabular (sparse text, mostly codes and numbers)
+    and consistently score below CA narrative text in semantic search.  This
+    secondary pass guarantees wage data appears in context for rate queries.
+    """
+    must: list[Condition] = [
+        FieldCondition(key="document_type", match=MatchValue(value="wage_schedule")),
+    ]
+    if union_filter:
+        must.append(
+            FieldCondition(key="union_name", match=MatchValue(value=union_filter))
+        )
+    response = await qdrant.query_points(
+        collection_name=COLLECTION,
+        query=vector,
+        query_filter=Filter(must=must),
+        limit=limit,
+        with_payload=True,
+    )
+    return [_point_to_chunk(hit) for hit in response.points]
+
+
+def _merge_with_wage_priority(
+    primary: list[ChunkResult],
+    wage: list[ChunkResult],
+    *,
+    limit: int = TOP_K,
+) -> list[ChunkResult]:
+    """Combine primary and wage results, deduplicating by point_id.
+
+    Wage chunks lead so they are always present in the context window.
+    Remaining slots are filled from the primary results.
+    """
+    seen: set[str] = set()
+    merged: list[ChunkResult] = []
+    for chunk in [*wage, *primary]:
+        if chunk.point_id not in seen:
+            seen.add(chunk.point_id)
+            merged.append(chunk)
+        if len(merged) >= limit:
+            break
+    return merged
+
+
 async def retrieve(
     query: str,
     *,
     union_filters: list[str] | None = None,
     include_nuclear_pa: bool = False,
     agreement_scope: str | None = None,
+    is_wage_query: bool = False,
     settings: Settings,
 ) -> list[ChunkResult]:
     """Embed *query* and retrieve the top-k matching chunks from Qdrant.
@@ -256,6 +309,9 @@ async def retrieve(
             contains nuclear-site context (see ``preprocess.detect_nuclear``).
         agreement_scope: Restrict to ``"generation"`` or ``"transmission"``
             for IBEW / Labourers queries.
+        is_wage_query: When ``True``, run a secondary wage_schedule-focused
+            retrieval pass and prepend those chunks so tabular rate data is
+            guaranteed to appear in the context window.
         settings: Application settings providing Qdrant and Ollama URLs.
 
     Returns:
@@ -278,13 +334,24 @@ async def retrieve(
             )
             for union_filter in unique_union_filters
         ]
-        return _merge_union_results(result_sets)
+        primary = _merge_union_results(result_sets)
+    else:
+        union_filter = unique_union_filters[0] if unique_union_filters else None
+        primary = await _query_qdrant(
+            qdrant,
+            vector=vector,
+            union_filter=union_filter,
+            include_nuclear_pa=include_nuclear_pa,
+            agreement_scope=agreement_scope,
+        )
 
-    union_filter = unique_union_filters[0] if unique_union_filters else None
-    return await _query_qdrant(
+    if not is_wage_query:
+        return primary
+
+    union_filter = unique_union_filters[0] if len(unique_union_filters) == 1 else None
+    wage_chunks = await _query_wage_schedules(
         qdrant,
         vector=vector,
         union_filter=union_filter,
-        include_nuclear_pa=include_nuclear_pa,
-        agreement_scope=agreement_scope,
     )
+    return _merge_with_wage_priority(primary, wage_chunks)

--- a/services/api/src/routes/query.py
+++ b/services/api/src/routes/query.py
@@ -178,6 +178,7 @@ async def query_handler(
         union_filters=ctx.union_filters,
         include_nuclear_pa=ctx.include_nuclear_pa,
         agreement_scope=ctx.agreement_scope,
+        is_wage_query=ctx.is_wage_query,
         settings=settings,
     )
 

--- a/services/api/tests/test_preprocess.py
+++ b/services/api/tests/test_preprocess.py
@@ -6,6 +6,7 @@ from src.rag.preprocess import (
     detect_scope,
     detect_union,
     detect_unions,
+    detect_wage_query,
     preprocess,
 )
 
@@ -196,6 +197,35 @@ class TestClassifyComplexity:
         assert classify_complexity("DIFFERENCE BETWEEN IBEW and UA") is True
 
 
+class TestDetectWageQuery:
+    def test_empty_query_returns_false(self) -> None:
+        assert detect_wage_query("") is False
+
+    def test_no_wage_keywords_returns_false(self) -> None:
+        assert detect_wage_query("What are the layoff notice requirements?") is False
+
+    def test_detects_rate(self) -> None:
+        assert detect_wage_query("What is the overtime rate for IBEW?") is True
+
+    def test_detects_wage(self) -> None:
+        assert detect_wage_query("IBEW wage schedule 2025") is True
+
+    def test_detects_hourly(self) -> None:
+        assert detect_wage_query("What is the hourly rate for electricians?") is True
+
+    def test_detects_journeyperson(self) -> None:
+        assert detect_wage_query("journeyperson pay for Sheet Metal Workers") is True
+
+    def test_detects_apprentice(self) -> None:
+        assert detect_wage_query("apprentice rate first period") is True
+
+    def test_case_insensitive(self) -> None:
+        assert detect_wage_query("HOURLY RATE for welders") is True
+
+    def test_non_wage_query_returns_false(self) -> None:
+        assert detect_wage_query("vacation entitlement after 5 years") is False
+
+
 class TestQueryContext:
     def test_default_values(self) -> None:
         ctx = QueryContext(
@@ -203,12 +233,14 @@ class TestQueryContext:
             include_nuclear_pa=False,
             agreement_scope=None,
             is_cross_union=False,
+            is_wage_query=False,
         )
         assert ctx.union_filters == []
         assert ctx.union_filter is None
         assert ctx.include_nuclear_pa is False
         assert ctx.agreement_scope is None
         assert ctx.is_cross_union is False
+        assert ctx.is_wage_query is False
 
     def test_all_fields_set(self) -> None:
         ctx = QueryContext(
@@ -216,22 +248,33 @@ class TestQueryContext:
             include_nuclear_pa=True,
             agreement_scope="generation",
             is_cross_union=True,
+            is_wage_query=True,
         )
         assert ctx.union_filters == ["IBEW"]
         assert ctx.union_filter == "IBEW"
         assert ctx.include_nuclear_pa is True
         assert ctx.agreement_scope == "generation"
         assert ctx.is_cross_union is True
+        assert ctx.is_wage_query is True
 
 
 class TestPreprocess:
     def test_simple_query_returns_all_defaults(self) -> None:
-        ctx = preprocess("What is the overtime rate?", KNOWN_UNIONS)
+        ctx = preprocess("What are the layoff notice requirements?", KNOWN_UNIONS)
         assert ctx.union_filters == []
         assert ctx.union_filter is None
         assert ctx.include_nuclear_pa is False
         assert ctx.agreement_scope is None
         assert ctx.is_cross_union is False
+        assert ctx.is_wage_query is False
+
+    def test_wage_query_sets_is_wage_query(self) -> None:
+        ctx = preprocess("What is the journeyperson hourly rate for IBEW?", KNOWN_UNIONS)
+        assert ctx.is_wage_query is True
+
+    def test_non_wage_query_does_not_set_is_wage_query(self) -> None:
+        ctx = preprocess("How many vacation days after 5 years?", KNOWN_UNIONS)
+        assert ctx.is_wage_query is False
 
     def test_nuclear_query_sets_include_nuclear_pa(self) -> None:
         ctx = preprocess("OPG site badge requirements", KNOWN_UNIONS)

--- a/services/api/tests/test_retrieval.py
+++ b/services/api/tests/test_retrieval.py
@@ -671,8 +671,8 @@ class TestMergeWithWagePriority:
         primary = [_make_chunk("ca-1"), _make_chunk("ca-2")]
         wage = [_make_chunk("ws-1", "wage_schedule")]
         result = _merge_with_wage_priority(primary, wage)
-        assert result[2].point_id == "ca-1"
-        assert result[3].point_id == "ca-2"
+        assert result[1].point_id == "ca-1"
+        assert result[2].point_id == "ca-2"
 
     def test_deduplicates_by_point_id(self) -> None:
         shared = _make_chunk("shared-1", "wage_schedule")

--- a/services/api/tests/test_retrieval.py
+++ b/services/api/tests/test_retrieval.py
@@ -29,6 +29,7 @@ from src.rag.retrieval import (
     TOP_K,
     ChunkResult,
     _merge_union_results,
+    _merge_with_wage_priority,
     _point_to_chunk,
     build_filter,
     retrieve,
@@ -636,3 +637,138 @@ class TestRetrieve:
             "Sheet Metal Workers",
             "IBEW",
         ]
+
+
+def _make_chunk(point_id: str, document_type: str = "primary_ca") -> ChunkResult:
+    return ChunkResult(
+        point_id=point_id,
+        score=0.9,
+        document_id="doc-1",
+        source_filename="test.pdf",
+        union_name="IBEW",
+        document_type=document_type,
+        agreement_scope=None,
+        effective_date=None,
+        expiry_date=None,
+        article_number=None,
+        article_title=None,
+        section_number=None,
+        page_number=None,
+        is_table=document_type == "wage_schedule",
+        text="text",
+    )
+
+
+class TestMergeWithWagePriority:
+    def test_wage_chunks_lead_in_output(self) -> None:
+        primary = [_make_chunk("ca-1"), _make_chunk("ca-2")]
+        wage = [_make_chunk("ws-1", "wage_schedule"), _make_chunk("ws-2", "wage_schedule")]
+        result = _merge_with_wage_priority(primary, wage)
+        assert result[0].point_id == "ws-1"
+        assert result[1].point_id == "ws-2"
+
+    def test_primary_chunks_fill_remaining_slots(self) -> None:
+        primary = [_make_chunk("ca-1"), _make_chunk("ca-2")]
+        wage = [_make_chunk("ws-1", "wage_schedule")]
+        result = _merge_with_wage_priority(primary, wage)
+        assert result[2].point_id == "ca-1"
+        assert result[3].point_id == "ca-2"
+
+    def test_deduplicates_by_point_id(self) -> None:
+        shared = _make_chunk("shared-1", "wage_schedule")
+        primary = [shared, _make_chunk("ca-1")]
+        wage = [shared, _make_chunk("ws-1", "wage_schedule")]
+        result = _merge_with_wage_priority(primary, wage)
+        ids = [c.point_id for c in result]
+        assert ids.count("shared-1") == 1
+
+    def test_respects_limit(self) -> None:
+        primary = [_make_chunk(f"ca-{i}") for i in range(8)]
+        wage = [_make_chunk(f"ws-{i}", "wage_schedule") for i in range(5)]
+        result = _merge_with_wage_priority(primary, wage, limit=10)
+        assert len(result) == 10
+
+    def test_empty_wage_returns_primary(self) -> None:
+        primary = [_make_chunk("ca-1"), _make_chunk("ca-2")]
+        result = _merge_with_wage_priority(primary, [])
+        assert [c.point_id for c in result] == ["ca-1", "ca-2"]
+
+    def test_empty_primary_returns_wage(self) -> None:
+        wage = [_make_chunk("ws-1", "wage_schedule")]
+        result = _merge_with_wage_priority([], wage)
+        assert result[0].point_id == "ws-1"
+
+
+class TestRetrieveWageQuery:
+    def _make_hit(self, point_id: str, document_type: str = "primary_ca") -> ScoredPoint:
+        hit = MagicMock(spec=ScoredPoint)
+        hit.id = point_id
+        hit.score = 0.85
+        hit.payload = {
+            "document_id": str(uuid.uuid4()),
+            "source_filename": "test.pdf",
+            "union_name": "IBEW",
+            "document_type": document_type,
+            "agreement_scope": None,
+            "effective_date": "2025-05-01",
+            "expiry_date": None,
+            "article_number": None,
+            "article_title": None,
+            "section_number": None,
+            "page_number": None,
+            "is_table": document_type == "wage_schedule",
+            "text": "text",
+        }
+        return hit
+
+    @pytest.mark.asyncio
+    async def test_wage_query_triggers_second_qdrant_call(
+        self, settings: Settings
+    ) -> None:
+        ca_hit = self._make_hit("ca-1")
+        wage_hit = self._make_hit("ws-1", "wage_schedule")
+
+        with (
+            patch("src.rag.retrieval.httpx.AsyncClient") as mock_http,
+            patch("src.rag.retrieval.AsyncQdrantClient") as mock_qdrant_cls,
+        ):
+            _make_ollama_mock(mock_http)
+            mock_qdrant = AsyncMock()
+            mock_qdrant.query_points = AsyncMock(
+                side_effect=[
+                    _make_query_response([ca_hit]),
+                    _make_query_response([wage_hit]),
+                ]
+            )
+            mock_qdrant_cls.return_value = mock_qdrant
+
+            results = await retrieve(
+                "journeyperson hourly rate for IBEW",
+                union_filters=["IBEW"],
+                is_wage_query=True,
+                settings=settings,
+            )
+
+        assert mock_qdrant.query_points.await_count == 2
+        assert results[0].point_id == "ws-1"
+        assert results[1].point_id == "ca-1"
+
+    @pytest.mark.asyncio
+    async def test_non_wage_query_uses_single_qdrant_call(
+        self, settings: Settings
+    ) -> None:
+        with (
+            patch("src.rag.retrieval.httpx.AsyncClient") as mock_http,
+            patch("src.rag.retrieval.AsyncQdrantClient") as mock_qdrant_cls,
+        ):
+            _make_ollama_mock(mock_http)
+            mock_qdrant = AsyncMock()
+            mock_qdrant.query_points = AsyncMock(return_value=_make_query_response([]))
+            mock_qdrant_cls.return_value = mock_qdrant
+
+            await retrieve(
+                "What are the layoff notice requirements?",
+                settings=settings,
+            )
+
+        assert mock_qdrant.query_points.await_count == 1


### PR DESCRIPTION
## Summary

- Tabular wage chunks (grade codes, column headers, dollar amounts) score far below CA narrative text in cosine similarity — with TOP_K=10 the CA fills all slots and zero wage_schedule chunks reach the model
- W01, W04, W07 eval questions all fail with "documents do not contain information about the journeyperson rate" even though 1062 IBEW wage chunks exist in Qdrant
- Root diagnosis: IBEW query returns 104 CA chunks competing with 1062 wage chunks; CA's Section 900A ("rates shall be set forth in the wage schedules") beats actual rate tables semantically
- Fix: `detect_wage_query()` in preprocess flags rate/wage/pay/hourly/journeyperson queries; `retrieve()` runs a second Qdrant pass forced to `document_type=wage_schedule` and prepends those chunks via `_merge_with_wage_priority()` — no reingest required

## Test plan

- [ ] `TestDetectWageQuery` — 9 new unit tests covering keyword detection
- [ ] `TestQueryContext` — updated for new `is_wage_query` field
- [ ] `TestPreprocess` — 2 new tests: wage query sets flag, non-wage query does not
- [ ] `TestMergeWithWagePriority` — 6 new unit tests: wage leads, dedup, limit, empty cases
- [ ] `TestRetrieveWageQuery` — 2 async tests: wage query triggers 2 Qdrant calls with wage chunks first; non-wage query uses 1 call
- [ ] Deploy → Dokploy redeploy epsca-api → test W01 query manually → run full Phase 1 eval